### PR TITLE
Lazy records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 docs/build/
 docs/site/
 *.jl.*.cov
+benchmark/.results/*.jld
+benchmark/.tune.jld

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 docs/build/
 docs/site/
+*.jl.*.cov

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,72 @@
+using PkgBenchmark
+using Memento
+
+const FMT_STR = "[{level}]:{name} - {msg}"
+
+function test_logger()
+    return Logger(
+        "Benchmarks",
+        Dict(
+            "Buffer" => DefaultHandler(
+                IOBuffer(),
+                DefaultFormatter(FMT_STR)
+            ),
+        ),
+        "info",
+        Dict(
+           "not_set" => 0,
+           "debug" => 10,
+           "info" => 20,
+           "warn" => 30,
+           "error" => 40,
+       ),
+       DefaultRecord,
+       true
+    )
+end
+
+function base_msg(level, name, msg; sleep_time=0.0)
+    d = Dict("level" => level, "name" => name, "msg" => msg)
+
+    function inner_func()
+        sleep(sleep_time)
+
+        result = FMT_STR
+        for key in ("level", "name", "msg")
+            result = replace(result, "{$key}", d[key])
+        end
+
+        return result
+    end
+end
+
+function memento_msg(msg; sleep_time=0.0)
+    function inner_func()
+        sleep(sleep_time)
+        return msg
+    end
+end
+
+@benchgroup "Simple `info`" begin
+    @bench "Base.info" info(io, base_msg("info", "Base", "Msg")()) setup=(io = IOBuffer())
+    @bench "Memento.info" info(memento_msg("Msg"), logger) setup=(logger = test_logger())
+    @bench "Memento.debug" debug(memento_msg("Msg"), logger) setup=(logger = test_logger())
+end
+
+@benchgroup "Expensive `info`" begin
+    @bench(
+        "Basic.info",
+        info(io, base_msg("info", "Base", "Msg"; sleep_time=0.1)()),
+        setup=(io = IOBuffer())
+    )
+    @bench(
+        "Memento.info",
+        info(memento_msg("Msg"; sleep_time=0.1), logger),
+        setup=(logger = test_logger())
+    )
+    @bench(
+        "Memento.debug",
+        debug(memento_msg("Msg"; sleep_time=0.1), logger),
+        setup=(logger = test_logger())
+    )
+end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -3,15 +3,13 @@ using Memento
 
 const FMT_STR = "[{level}|{name}] - {msg}"
 
-function memento_setup()
+"""
+Sets up our memento logger with a given formatter.
+"""
+function memento_setup(fmt=DefaultFormatter(FMT_STR))
     return Logger(
         "Benchmarks",
-        Dict(
-            "Buffer" => DefaultHandler(
-                IOBuffer(),
-                DefaultFormatter(FMT_STR)
-            ),
-        ),
+        Dict("Buffer" => DefaultHandler(IOBuffer(),fmt)),
         "info",
         Dict(
            "not_set" => 0,
@@ -25,6 +23,11 @@ function memento_setup()
     )
 end
 
+"""
+Builds up a log message comparable to the default log messages
+produced in Memento w/ the option to sleep to mimic expensive message
+generations.
+"""
 function base_msg(level, name, msg; sleep_time=0.0)
     d = Dict("level" => level, "name" => name, "msg" => msg)
 
@@ -40,6 +43,10 @@ function base_msg(level, name, msg; sleep_time=0.0)
     end
 end
 
+"""
+Mocks passing the memento message as a funtion w/
+the option to sleep to mimic expensive message generation functions.
+"""
 function memento_msg(msg; sleep_time=0.0)
     function inner_func()
         sleep(sleep_time)
@@ -47,26 +54,99 @@ function memento_msg(msg; sleep_time=0.0)
     end
 end
 
-@benchgroup "Common Logging" begin
-    @bench "Base.info" info(io, base_msg("info", "Base", "Msg")()) setup=(io = IOBuffer())
-    @bench "Memento.info" info(memento_msg("Msg"), logger) setup=(logger = memento_setup())
-    @bench "Memento.debug" debug(memento_msg("Msg"), logger) setup=(logger = memento_setup())
+# Some basic benchmarks of logging in base julia as a point of reference.
+@benchgroup "Base" begin
+    @bench(
+        "Logging raw string",
+        info(io, "[info|Base] - Msg"),
+        setup=(io = IOBuffer()),
+    )
+    @bench(
+        "Loggin with interpolation (delay 0.0)",
+        info(io, base_msg("info", "Base", "Msg")()),
+        setup=(io = IOBuffer()),
+    )
+    @bench(
+        "Logging with interpolation (delay 0.1)",
+        info(io, base_msg("info", "Base", "Msg"; sleep_time=0.1)()),
+        setup=(io = IOBuffer()),
+    )
 end
 
-@benchgroup "Expensive Logging" begin
+# All our Memento.jl benchmarks.
+# NOTE: we're trying to mostly benchmark the general API rather than
+# individual components as the implementation may change significantly between
+# iterations.
+@benchgroup "Memento" begin
     @bench(
-        "Basic.info",
-        info(io, base_msg("info", "Base", "Msg"; sleep_time=0.1)()),
-        setup=(io = IOBuffer())
+        "Unfiltered log (delay 0.0)",
+        info(memento_msg("Msg"), logger),
+        setup=(logger = memento_setup()),
     )
     @bench(
-        "Memento.info",
+        "Filtered log (delay 0.0)",
+        debug(memento_msg("Msg"), logger),
+        setup=(logger = memento_setup()),
+    )
+    @bench(
+        "Unfiltered log (delay 0.1)",
         info(memento_msg("Msg"; sleep_time=0.1), logger),
-        setup=(logger = memento_setup())
+        setup=(logger = memento_setup()),
     )
     @bench(
-        "Memento.debug",
+        "Filtered log (delay 0.1)",
         debug(memento_msg("Msg"; sleep_time=0.1), logger),
-        setup=(logger = memento_setup())
+        setup=(logger = memento_setup()),
+    )
+    @bench(
+        "Unfiltered log with StackTrace",
+        info(memento_msg("Msg"), logger),
+        setup=(logger = memento_setup(DefaultFormatter("[{level}] - {msg} -> {stacktrace}"))),
+    )
+    @bench(
+        "Filtered log with StackTrace",
+        debug(memento_msg("Msg"; sleep_time=0.1), logger),
+        setup=(logger = memento_setup(DefaultFormatter("[{level}] - {msg} -> {stacktrace}"))),
+    )
+    @bench(
+        "Unfiltered log as JSON (no aliases)",
+        info(memento_msg("Msg"), logger),
+        setup=(logger = memento_setup(JsonFormatter())),
+    )
+    @bench(
+        "Filtered log as JSON (no aliases)",
+        debug(memento_msg("Msg"), logger),
+        setup=(logger = memento_setup(JsonFormatter())),
+    )
+    no_trace_aliases = Dict(
+        :message => :msg,
+        :level => :level,
+        :logger => :name,
+    )
+    @bench(
+        "Unfiltered log as JSON (aliases w/o trace)",
+        info(memento_msg("Msg"), logger),
+        setup=(logger = memento_setup(JsonFormatter($no_trace_aliases))),
+    )
+    @bench(
+        "Filtered log as JSON (aliases w/o trace)",
+        debug(memento_msg("Msg"), logger),
+        setup=(logger = memento_setup(JsonFormatter($no_trace_aliases))),
+    )
+    trace_aliases = Dict(
+        :backtrace => :stacktrace,
+        :message => :msg,
+        :level => :level,
+        :logger => :name,
+    )
+    @bench(
+        "Unfiltered log as JSON (aliases w/ trace)",
+        info(memento_msg("Msg"), logger),
+        setup=(logger = memento_setup(JsonFormatter($trace_aliases))),
+    )
+    @bench(
+        "Filtered log as JSON (aliases w/ trace)",
+        debug(memento_msg("Msg"), logger),
+        setup=(logger = memento_setup(JsonFormatter($trace_aliases))),
     )
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,9 +1,9 @@
 using PkgBenchmark
 using Memento
 
-const FMT_STR = "[{level}]:{name} - {msg}"
+const FMT_STR = "[{level}|{name}] - {msg}"
 
-function test_logger()
+function memento_setup()
     return Logger(
         "Benchmarks",
         Dict(
@@ -47,13 +47,13 @@ function memento_msg(msg; sleep_time=0.0)
     end
 end
 
-@benchgroup "Simple `info`" begin
+@benchgroup "Common Logging" begin
     @bench "Base.info" info(io, base_msg("info", "Base", "Msg")()) setup=(io = IOBuffer())
-    @bench "Memento.info" info(memento_msg("Msg"), logger) setup=(logger = test_logger())
-    @bench "Memento.debug" debug(memento_msg("Msg"), logger) setup=(logger = test_logger())
+    @bench "Memento.info" info(memento_msg("Msg"), logger) setup=(logger = memento_setup())
+    @bench "Memento.debug" debug(memento_msg("Msg"), logger) setup=(logger = memento_setup())
 end
 
-@benchgroup "Expensive `info`" begin
+@benchgroup "Expensive Logging" begin
     @bench(
         "Basic.info",
         info(io, base_msg("info", "Base", "Msg"; sleep_time=0.1)()),
@@ -62,11 +62,11 @@ end
     @bench(
         "Memento.info",
         info(memento_msg("Msg"; sleep_time=0.1), logger),
-        setup=(logger = test_logger())
+        setup=(logger = memento_setup())
     )
     @bench(
         "Memento.debug",
         debug(memento_msg("Msg"; sleep_time=0.1), logger),
-        setup=(logger = test_logger())
+        setup=(logger = memento_setup())
     )
 end

--- a/docs/src/man/conclusion.md
+++ b/docs/src/man/conclusion.md
@@ -59,28 +59,35 @@ logger = basic_config("info"; fmt="[{level} | {name}]: {msg}")
 
 # We create our custom EC2Record type
 type EC2Record <: Record
-    dict::Dict{Symbol, Any}
+    date::Attribute
+    level::Attribute
+    levelnum::Attribute
+    msg::Attribute
+    name::Attribute
+    pid::Attribute
+    lookup::Attribute
+    stacktrace::Attribute
+    instance_id::Attribute
+    public_ip::Attribute
+    iam_user::Attribute
 
     function EC2Record(args::Dict)
-        trace = StackTraces.remove_frames!(
-            StackTraces.stacktrace(),
-            [:DefaultRecord, :log, Symbol("#log#22"), :info, :warn, :debug]
-        )
+        time = now()
+        trace = Attribute(StackTrace, get_trace)
 
-        new(Dict(
-            :date => round(now(), Base.Dates.Second),
-            :level => args[:level],
-            :levelnum => args[:levelnum],
-            :msg => args[:msg],
-            :name => args[:name],
-            :pid => myid(),
-            :lookup => isempty(trace) ? nothing : first(trace),
-            :stacktrace => trace,
-            :instance_id => ENV["INSTANCE_ID"],
-            :public_ip => ENV["PUBLIC_IP"],
-            :iam_user => ENV["IAM_USER"],
-            # Other things?
-        ))
+        EC2Record(
+            Attribute(DateTime, () -> round(time, Base.Dates.Second)),
+            Attribute(args[:level]),
+            Attribute(args[:levelnum]),
+            Attribute(AbstractString, get_msg(args[:msg])),
+            Attribute(args[:name]),
+            Attribute(myid()),
+            Attribute(StackFrame, get_lookup(trace)),
+            trace,
+            Attribute(ENV["INSTANCE_ID"]),
+            Attribute(ENV["PUBLIC_IP"]),
+            Attribute(ENV["IAM_USER"]),
+        )
     end
 end
 

--- a/docs/src/man/handlers.md
+++ b/docs/src/man/handlers.md
@@ -9,7 +9,7 @@ type MyHandler{F<:Formatter, O<:IO} <: Handler{F, O}
     io::O
 end
 
-function log{F<:Formatter, O<:IO}(handler::MyHandler{F, O}, rec::Record)
+function emit{F<:Formatter, O<:IO}(handler::MyHandler{F, O}, rec::Record)
     str = format(handler.fmt, rec)
     println(handler.io, str)
     flush(handler.io)
@@ -21,7 +21,7 @@ behaviour based on the `Formatter`, `IO` or `Record` types being used.
 For example, the `Syslog` `IO` type needs an extra `level` argument to
 its `println` so we special case this like so:
 ```julia
-function log{F<:Formatter, O<:Syslog}(handler::MyHandler{F, O}, rec::Record)
+function emit{F<:Formatter, O<:Syslog}(handler::MyHandler{F, O}, rec::Record)
     str = format(handler.fmt, rec)
     println(handler.io, rec[:level], str)
     flush(handler.io)

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -24,7 +24,7 @@ export log, debug, info, notice, warn, error, critical, alert, emergency,
 
 const DEFAULT_LOG_LEVEL = "warn"
 
-global _log_levels = Dict{AbstractString, Int}(
+const global _log_levels = Dict{AbstractString, Int}(
     "not_set" => 0,
     "debug" => 10,
     "info" => 20,
@@ -46,7 +46,7 @@ include("handlers.jl")
 include("loggers.jl")
 
 function __init__()
-    global _loggers = Dict{Any, Logger}(
+    global _loggers = Dict{AbstractString, Logger}(
         "root" => Logger("root"),
     )
 end

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -4,7 +4,7 @@ module Memento
 
 using Mocking
 
-import Base: show, info, warn, error, log, write, Filter
+import Base: show, info, warn, error, log
 
 if !isdefined(Base, :StackTraces)
     import StackTraces
@@ -12,12 +12,11 @@ end
 
 export log, debug, info, notice, warn, error, critical, alert, emergency,
        is_set, is_root, set_level, add_level, set_record, add_filter,
-       add_handler, remove_handler, remove_handlers, write,
+       add_handler, remove_handler, remove_handlers, emit,
        basic_config, get_logger, get_handlers, format,
 
        Logger,
        Record, DefaultRecord,
-       Filter,
        Formatter, DefaultFormatter, JsonFormatter,
        Handler, DefaultHandler,
        FileRoller, Syslog

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -4,19 +4,20 @@ module Memento
 
 using Mocking
 
-import Base: show, info, warn, error, log
+import Base: show, info, warn, error, log, Filter
 
 if !isdefined(Base, :StackTraces)
     import StackTraces
 end
 
 export log, debug, info, notice, warn, error, critical, alert, emergency,
-       is_set, is_root, set_level, add_level, set_record,
+       is_set, is_root, set_level, add_level, set_record, add_filter,
        add_handler, remove_handler, remove_handlers,
        basic_config, get_logger, get_handlers, format,
 
        Logger,
        Record, DefaultRecord,
+       Filter,
        Formatter, DefaultFormatter, JsonFormatter,
        Handler, DefaultHandler,
        FileRoller, Syslog
@@ -40,6 +41,7 @@ global _loggers
 
 include("io.jl")
 include("records.jl")
+include("filters.jl")
 include("formatters.jl")
 include("handlers.jl")
 include("loggers.jl")

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -4,7 +4,7 @@ module Memento
 
 using Mocking
 
-import Base: show, info, warn, error, log, Filter
+import Base: show, info, warn, error, log, write, Filter
 
 if !isdefined(Base, :StackTraces)
     import StackTraces
@@ -12,7 +12,7 @@ end
 
 export log, debug, info, notice, warn, error, critical, alert, emergency,
        is_set, is_root, set_level, add_level, set_record, add_filter,
-       add_handler, remove_handler, remove_handlers,
+       add_handler, remove_handler, remove_handlers, write,
        basic_config, get_logger, get_handlers, format,
 
        Logger,

--- a/src/filters.jl
+++ b/src/filters.jl
@@ -1,0 +1,9 @@
+immutable LogFilter
+    f::Function
+end
+
+Filter(f::Function) = LogFilter(f)
+
+function (filter::LogFilter)(rec::Record)::Bool
+    return filter.f(rec)
+end

--- a/src/filters.jl
+++ b/src/filters.jl
@@ -1,9 +1,7 @@
-immutable LogFilter
+immutable Filter
     f::Function
 end
 
-Filter(f::Function) = LogFilter(f)
-
-function (filter::LogFilter)(rec::Record)::Bool
+function (filter::Filter)(rec::Record)::Bool
     return filter.f(rec)
 end

--- a/src/filters.jl
+++ b/src/filters.jl
@@ -1,3 +1,12 @@
+"""
+    Filter
+
+I wrapper around a function that takes a log `Record` and returns
+a bool whether to skip logging it.
+
+# Fields
+`f::Function`: a function that should return a bool given a `Record`
+"""
 immutable Filter
     f::Function
 end

--- a/src/formatters.jl
+++ b/src/formatters.jl
@@ -37,21 +37,21 @@ function format(fmt::DefaultFormatter, rec::Record)
 
     for token in fmt.tokens
         field = Symbol(token)
+        tmp_val = rec[field]
 
         value = if field === :lookup
             # lookup is a StackFrame
-            frame = get(rec, field)
-            name, file, line = frame.func, frame.file, frame.line
+            name, file, line = tmp_val.func, tmp_val.file, tmp_val.line
             "$(name)@$(basename(string(file))):$(line)"
         elseif field === :stacktrace
             # stacktrace is a vector of StackFrames
-            str_frames = map(get(rec, field)) do frame
+            str_frames = map(tmp_val) do frame
                 string(frame.func, "@", basename(string(frame.file)), ":", frame.line)
             end
 
             string(" stack:[", join(str_frames, ", "), "]")
         else
-            get(rec, field)
+            tmp_val
         end
 
         result = replace(result, "{$token}", value)
@@ -86,7 +86,7 @@ function format(fmt::JsonFormatter, rec::Record)
     dict = Dict{Symbol, Any}()
 
     for (alias, key) in aliases
-        tmp_val = get(rec, key)
+        tmp_val = rec[key]
 
         value = if key === :date
             string(tmp_val)

--- a/src/formatters.jl
+++ b/src/formatters.jl
@@ -1,6 +1,8 @@
 using JSON
 
 """
+    Formatter
+
 A `Formatter` must implement a `format(::Formatter, ::Record)` method
 which takes a `Record` and returns a `String` representation of the
 log `Record`.
@@ -10,6 +12,8 @@ abstract Formatter
 const DEFAULT_FMT_STRING = "[{level} | {name}]: {msg}"
 
 """
+    DefaultFormatter
+
 The `DefaultFormatter` uses a simple format string to build
 the log message. Fields from the `Record` to be used should be
 wrapped curly brackets.
@@ -39,7 +43,9 @@ immutable DefaultFormatter <: Formatter
 end
 
 """
-`format(::DefaultFormatter, ::Record)` iteratively replaces entries in the
+    format(::DefaultFormatter, ::Record) -> String
+
+Iteratively replaces entries in the
 format string with the appropriate fields in the `Record`
 """
 function format(fmt::DefaultFormatter, rec::Record)
@@ -75,7 +81,9 @@ function format(fmt::DefaultFormatter, rec::Record)
 end
 
 """
-`JsonFormatter` uses the JSON pkg to format the `Record` into a valid
+    JsonFormatter
+
+Uses the JSON pkg to format the `Record` into a valid
 JSON string.
 """
 type JsonFormatter <: Formatter
@@ -86,7 +94,9 @@ type JsonFormatter <: Formatter
 end
 
 """
-`format(::JsonFormatter, ::Record)` converts :date, :lookup and :stacktrace to strings
+    format(::JsonFormatter, ::Record) -> String
+
+Converts :date, :lookup and :stacktrace to strings
 and dicts respectively and call `JSON.json()` on the resulting dictionary.
 """
 function format(fmt::JsonFormatter, rec::Record)

--- a/src/formatters.jl
+++ b/src/formatters.jl
@@ -21,9 +21,10 @@ Ex) "[{level} | {name}]: {msg}" will print message of the form
 """
 immutable DefaultFormatter <: Formatter
     fmt_str::AbstractString
+    tokens::Vector{SubString{String}}
 
     function DefaultFormatter(fmt_str::AbstractString=DEFAULT_FMT_STRING)
-        new(fmt_str)
+        new(fmt_str, matchall(r"(?<={).+?(?=})", fmt_str))
     end
 end
 
@@ -32,24 +33,27 @@ end
 format string with the appropriate fields in the `Record`
 """
 function format(fmt::DefaultFormatter, rec::Record)
-    dict = Dict(rec)
     result = fmt.fmt_str
 
-    for field in keys(dict)
-        if field === :lookup
+    for token in fmt.tokens
+        field = Symbol(token)
+
+        value = if field === :lookup
             # lookup is a StackFrame
             name, file, line = dict[field].func, dict[field].file, dict[field].line
-            dict[field] = "$(name)@$(basename(string(file))):$(line)"
+            "$(name)@$(basename(string(file))):$(line)"
         elseif field === :stacktrace
             # stacktrace is a vector of StackFrames
-            dict[field] = string(
+            string(
                 " stack:[",
                 join(map(f->"$(f.func)@$(basename(string(f.file))):$(f.line)", dict[field]), ", "),
                 "]"
             )
+        else
+            rec[field]
         end
 
-        result = replace(result, "{$field}", dict[field])
+        result = replace(result, "{$token}", value)
     end
 
     return result
@@ -59,36 +63,49 @@ end
 `JsonFormatter` uses the JSON pkg to format the `Record` into a valid
 JSON string.
 """
-type JsonFormatter <: Formatter end
+type JsonFormatter <: Formatter
+    aliases::Nullable{Dict{Symbol, Symbol}}
+
+    JsonFormatter() = new(Nullable())
+    JsonFormatter(aliases::Dict{Symbol, Symbol}) = new(Nullable(aliases))
+end
 
 """
 `format(::JsonFormatter, ::Record)` converts :date, :lookup and :stacktrace to strings
 and dicts respectively and call `JSON.json()` on the resulting dictionary.
 """
 function format(fmt::JsonFormatter, rec::Record)
-    dict = Dict(rec)
-
-    if haskey(dict, :date)
-        dict[:date] = string(dict[:date])
+    aliases = if isnull(fmt.aliases)
+        Dict(zip(keys(rec), keys(rec)))
+    else
+        get(fmt.aliases)
     end
 
-    if haskey(dict, :lookup)
-        dict[:lookup] = Dict(
-            :name => dict[:lookup].func,
-            :file => basename(string(dict[:lookup].file)),
-            :line => dict[:lookup].line
-        )
-    end
+    dict = Dict{Symbol, Any}()
 
-    if haskey(dict, :stacktrace)
-        dict[:stacktrace] = map(
-            f -> Dict(
-                :name => f.func,
-                :file => basename(string(f.file)),
-                :line => f.line
-            ),
-            dict[:stacktrace]
-        )
+    for (alias, key) in aliases
+        value = if key === :date
+            string(rec[:date])
+        elseif key === :lookup
+            Dict(
+                :name => rec[:lookup].func,
+                :file => basename(string(rec[:lookup].file)),
+                :line => rec[:lookup].line
+            )
+        elseif key === :stacktrace
+            map(
+                f -> Dict(
+                    :name => f.func,
+                    :file => basename(string(f.file)),
+                    :line => f.line
+                ),
+                rec[:stacktrace]
+            )
+        else
+            rec[key]
+        end
+
+        dict[alias] = value
     end
 
     return json(dict)

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -11,7 +11,7 @@ abstract Handler{F<:Formatter, O<:IO}
 
 function Memento.Filter(h::Handler)
     function level_filter(rec::Record)
-        level = get(rec, :level)
+        level = rec[:level]
         return h.levels.x[level] >= h.levels.x[h.level]
     end
 
@@ -120,7 +120,7 @@ end
 logs all records with any `Formatter` and `IO` types.
 """
 function emit{F<:Formatter, O<:IO}(handler::DefaultHandler{F, O}, rec::Record)
-    level = get(rec, :level)
+    level = rec[:level]
     str = format(handler.fmt, rec)
 
     if handler.opts[:is_colorized] && haskey(handler.opts[:colors], level)
@@ -142,6 +142,6 @@ logs all records with any `Formatter` and a `Syslog` `IO` type.
 """
 function emit{F<:Formatter, O<:Syslog}(handler::DefaultHandler{F, O}, rec::Record)
     str = format(handler.fmt, rec)
-    println(handler.io, get(rec, :level), str)
+    println(handler.io, rec[:level], str)
     flush(handler.io)
 end

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -1,5 +1,7 @@
 """
-`Handlers` manage formatting `Record`s and printing
+    Handler
+
+Manage formatting `Record`s and printing
 the resulting `String` to an `IO` type. All `Handler`
 subtypes must implement at least 1 `log(::Handler, ::Record)`
 method.
@@ -18,6 +20,12 @@ function Memento.Filter(h::Handler)
     Memento.Filter(level_filter)
 end
 
+"""
+    log(handler::Handler, rec::Record)
+
+Checks the `Handler` filters and if they all pass then
+`emit` the record.
+"""
 function log(handler::Handler, rec::Record)
     if all(f -> f(rec), filters(handler))
         emit(handler, rec)
@@ -25,6 +33,8 @@ function log(handler::Handler, rec::Record)
 end
 
 """
+    DefaultHanlder
+
 The DefaultHandler manages any `Formatter`, `IO` and `Record`.
 
 Fields:
@@ -50,13 +60,14 @@ type DefaultHandler{F<:Formatter, O<:IO} <: Handler{F, O}
 end
 
 """
-`DefaultHandler{F<Formatter, O<:IO}(io::O, fmt::F, opts::Dict{Symbol, Any})`
-creates a DefaultHandler with the specified IO type.
+    DefaultHandler{F<Formatter, O<:IO}(io::O, fmt::F, opts::Dict{Symbol, Any})
 
-Args:
-- io: the IO type
-- fmt: the Formatter to use (default to `DefaultFormatter()`)
-- opts: the optional arguments (defaults to `Dict{Symbol, Any}()`)
+Creates a DefaultHandler with the specified IO type.
+
+# Arguments
+* `io::IO`: the IO type
+* `fmt::Formatter`: the Formatter to use (default to `DefaultFormatter()`)
+* `opts::Dict`: the optional arguments (defaults to `Dict{Symbol, Any}()`)
 """
 function DefaultHandler{F<:Formatter, O<:IO}(io::O, fmt::F=DefaultFormatter(), opts=Dict{Symbol, Any}())
     setup_opts(opts)
@@ -66,13 +77,14 @@ function DefaultHandler{F<:Formatter, O<:IO}(io::O, fmt::F=DefaultFormatter(), o
 end
 
 """
-`DefaultHandler{F<Formatter}(filename::AbstractString, fmt::F, opts::Dict{Symbol, Any})`
-creates a DefaultHandler with a IO handle to the specified filename.
+    DefaultHandler{F<Formatter}(filename::AbstractString, fmt::F, opts::Dict{Symbol, Any})`
 
-Args:
-- filename: the filename of a log file to write to
-- fmt: the Formatter to use (default to `DefaultFormatter()`)
-- opts: the optional arguments (defaults to `Dict{Symbol, Any}()`)
+Creates a DefaultHandler with a IO handle to the specified filename.
+
+# Arguments
+* `filename::AbstractString`: the filename of a log file to write to
+* `fmt::Formatter`: the Formatter to use (default to `DefaultFormatter()`)
+* `opts::Dict`: the optional arguments (defaults to `Dict{Symbol, Any}()`)
 """
 function DefaultHandler{F<:Formatter}(filename::AbstractString, fmt::F=DefaultFormatter(), opts=Dict{Symbol, Any}())
     file = open(filename, "a")
@@ -84,7 +96,9 @@ function DefaultHandler{F<:Formatter}(filename::AbstractString, fmt::F=DefaultFo
 end
 
 """
-`setup_opts(opts)` sets the default :colors if `opts[:is_colorized] == true`
+    setup_opts(opts) -> Dict
+
+Sets the default :colors if `opts[:is_colorized] == true`.
 """
 function setup_opts(opts)
     if haskey(opts, :colors)
@@ -108,16 +122,27 @@ function setup_opts(opts)
     opts
 end
 
+"""
+    filters(handler::DefaultHandler) -> Array{Filter}
+
+Returns the filters for the handler.
+"""
 filters(handler::DefaultHandler) = handler.filters
 
+"""
+    set_level(handler::DefaultHandler, level::AbstractString)
+
+Sets the minimum level required to `emit` the record from the handler.
+"""
 function set_level(handler::DefaultHandler, level::AbstractString)
     handler.levels.x[level]     # Throw a key error if the levels isn't in levels
     handler.level = level
 end
 
 """
-`log{F<:Formatter, O<:IO}(handler::DefaultHandler{F ,O}, rec::Record)`
-logs all records with any `Formatter` and `IO` types.
+    emit{F<:Formatter, O<:IO}(handler::DefaultHandler{F ,O}, rec::Record)
+
+Handles printing any `Record` with any `Formatter` and `IO` types.
 """
 function emit{F<:Formatter, O<:IO}(handler::DefaultHandler{F, O}, rec::Record)
     level = rec[:level]
@@ -137,8 +162,9 @@ function emit{F<:Formatter, O<:IO}(handler::DefaultHandler{F, O}, rec::Record)
 end
 
 """
-`logs{F<:Formatter, O<:Syslog}(handler::DefaultHandler{F, O}, rec::Record)`
-logs all records with any `Formatter` and a `Syslog` `IO` type.
+    emit{F<:Formatter, O<:Syslog}(handler::DefaultHandler{F, O}, rec::Record)
+
+Handles printing any records with any `Formatter` and a `Syslog` `IO` type.
 """
 function emit{F<:Formatter, O<:Syslog}(handler::DefaultHandler{F, O}, rec::Record)
     str = format(handler.fmt, rec)

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -11,7 +11,7 @@ abstract Handler{F<:Formatter, O<:IO}
 
 function Memento.Filter(h::Handler)
     function level_filter(rec::Record)
-        level = rec[:level]
+        level = get(rec, :level)
 
         if haskey(h.levels.x, level)
             return h.levels.x[level] >= h.levels.x[h.level]
@@ -132,7 +132,7 @@ end
 logs all records with any `Formatter` and `IO` types.
 """
 function emit{F<:Formatter, O<:IO}(handler::DefaultHandler{F, O}, rec::Record)
-    level = rec[:level]
+    level = get(rec, :level)
     str = format(handler.fmt, rec)
 
     if handler.opts[:is_colorized] && haskey(handler.opts[:colors], level)
@@ -154,6 +154,6 @@ logs all records with any `Formatter` and a `Syslog` `IO` type.
 """
 function emit{F<:Formatter, O<:Syslog}(handler::DefaultHandler{F, O}, rec::Record)
     str = format(handler.fmt, rec)
-    println(handler.io, rec[:level], str)
+    println(handler.io, get(rec, :level), str)
     flush(handler.io)
 end

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -12,13 +12,7 @@ abstract Handler{F<:Formatter, O<:IO}
 function Memento.Filter(h::Handler)
     function level_filter(rec::Record)
         level = get(rec, :level)
-
-        if haskey(h.levels.x, level)
-            return h.levels.x[level] >= h.levels.x[h.level]
-        else
-            warn("$level not in $(h.levels.x)")
-            return false
-        end
+        return h.levels.x[level] >= h.levels.x[h.level]
     end
 
     Memento.Filter(level_filter)

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -18,12 +18,6 @@ function Memento.Filter(h::Handler)
     Memento.Filter(level_filter)
 end
 
-filters(handler::Handler) = Memento.Filter[]
-
-function add_filter(handler::Handler, filter::Memento.Filter)
-    push!(filters(handler), filter)
-end
-
 function log(handler::Handler, rec::Record)
     if all(f -> f(rec), filters(handler))
         emit(handler, rec)

--- a/src/io.jl
+++ b/src/io.jl
@@ -3,16 +3,17 @@ import Base.println, Base.flush
 const DEFAULT_MAX_FILE_SIZE = 5000 * 1028
 
 """
-A `FileRoller` is responsible for managing a rolling
+    FileRoller <: IO
+
+Is responsible for managing a rolling
 log file.
 
-Fields:
-
-- `prefix`: filename prefix for the log.
-- `folder`: directory where the log should be written.
-- `file`: the current file IO handle
-- `byteswritten`: keeps track of how many bytes have been written to the current file.
-- `max_sz`: the maximum number of bytes written to a file before rolling over to another.
+# Fields
+* `prefix::AbstractString`: filename prefix for the log.
+* `folder::AbstractString`: directory where the log should be written.
+* `file::AbstractString`: the current file IO handle
+* `byteswritten::Int64`: keeps track of how many bytes have been written to the current file.
+* `max_sz::Int`: the maximum number of bytes written to a file before rolling over to another.
 """
 type FileRoller <: IO
     prefix::AbstractString
@@ -24,7 +25,9 @@ type FileRoller <: IO
 end
 
 """
-`getsuffix(::Integer)` formats the nth file suffix.
+    getsuffix(::Integer) -> String
+
+Formats the nth file suffix.
 """
 function getsuffix(n::Integer)
     str = string(n)
@@ -35,8 +38,9 @@ function getsuffix(n::Integer)
 end
 
 """
-`getfile(folder::AbstractString, prefix::AbstractString)`
-grabs the next log file.
+    getfile(folder::AbstractString, prefix::AbstractString) -> String, IO
+
+Grabs the next log file.
 """
 function getfile(folder::AbstractString, prefix::AbstractString)
     i = 1
@@ -50,22 +54,27 @@ function getfile(folder::AbstractString, prefix::AbstractString)
 end
 
 """
-`FileRoller(prefix; max_size=DEFAULT_MAX_FILE_SIZE)` creates a rolling log file in the
-current working directory with the specified prefix.
+    FileRoller(prefix; max_size=DEFAULT_MAX_FILE_SIZE)
+
+Creates a rolling log file in the current working directory
+with the specified prefix.
 """
 FileRoller(prefix; max_sz=DEFAULT_MAX_FILE_SIZE) = FileRoller(prefix, pwd(); max_sz=max_sz)
 
 """
-`FileRoller(prefix, dir; max_size=DEFAULT_MAX_FILE_SIZE)` creates a rolling log file in the
-specified directory with the given prefix.
+    FileRoller(prefix, dir; max_size=DEFAULT_MAX_FILE_SIZE)
+
+Creates a rolling log file in the specified directory with the given prefix.
 """
 function FileRoller(prefix, dir; max_sz=DEFAULT_MAX_FILE_SIZE)
     FileRoller(prefix, dir, (getfile(dir, prefix))..., 0, max_sz)
 end
 
 """
-`println(::FileRoller, ::AbstractString)` writes the string to a file
-and creates a new file if we've reached the max file size.
+    println(::FileRoller, ::AbstractString)
+
+Writes the string to a file and creates a new file if
+we've reached the max file size.
 """
 function println(f::FileRoller, s::AbstractString)
     if f.byteswritten > f.max_sz
@@ -78,7 +87,9 @@ function println(f::FileRoller, s::AbstractString)
 end
 
 """
-`flush(::FileRoller)` flushes the current open file.
+    flush(::FileRoller)
+
+Flushes the current open file.
 """
 flush(f::FileRoller) = flush(f.file)
 
@@ -93,14 +104,15 @@ FACILITIES = [
 ]
 
 """
+    Syslog <: IO
+
 `Syslog` handle writing message to `syslog` by shelling out to the
 `logger` command.
 
-Fields:
-
-- `facility`: The syslog facility to write to (e.g., :local0, :ft, :daemon, etc) (defaults to :local0)
-- `tag`: a tag to use for all message (defaults to "julia")
-- `pid`: tags julia's pid to messages (defaults to -1 which doesn't include the pid)
+# Fields
+* `facility::Symbol`: The syslog facility to write to (e.g., :local0, :ft, :daemon, etc) (defaults to :local0)
+* `tag::AbstractString`: a tag to use for all message (defaults to "julia")
+* `pid::Integer`: tags julia's pid to messages (defaults to -1 which doesn't include the pid)
 """
 type Syslog <: IO
     facility::Symbol
@@ -126,8 +138,10 @@ type Syslog <: IO
 end
 
 """
-`println(::Syslog, ::Symbol, ::AbstractString)` writes the AbstractString
-to `logger` with the Symbol representing the syslog level.
+    println(::Syslog, ::Symbol, ::AbstractString)
+
+Writes the AbstractString to `logger` with the Symbol
+representing the syslog level.
 """
 function println(log::Syslog, level::Symbol, msg::AbstractString)
     level = get(ALIAS_LEVELS, level, level)
@@ -142,15 +156,18 @@ function println(log::Syslog, level::Symbol, msg::AbstractString)
 end
 
 """
-`println(::Syslog, ::AbstractString, ::AbstractString)` converts the first
-AbstractString to a Symbol and call `println(::Syslog, ::Symbol, ::AbstractString)`
+    println(::Syslog, ::AbstractString, ::AbstractString)
+
+Converts the first AbstractString to a Symbol and call
+`println(::Syslog, ::Symbol, ::AbstractString)`
 """
 function println(log::Syslog, level::AbstractString, msg::AbstractString)
     println(log, Symbol(lowercase(level)), msg)
 end
 
 """
-`flush(::Syslog)` is defined just in case somebody decides
-to call flush, which is unnecessary.
+    flush(::Syslog)
+
+Is defined just in case somebody decides to call flush, which is unnecessary.
 """
 flush(log::Syslog) = log

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -62,13 +62,7 @@ end
 function Memento.Filter(l::Logger)
     function level_filter(rec::Record)
         level = get(rec, :level)
-
-        if haskey(l.levels, level)
-            return l.levels[level] >= l.levels[l.level]
-        else
-            warn("$level not in $(l.levels)")
-            return false
-        end
+        return l.levels[level] >= l.levels[l.level]
     end
 
     Memento.Filter(level_filter)

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -61,7 +61,7 @@ end
 
 function Memento.Filter(l::Logger)
     function level_filter(rec::Record)
-        level = get(rec, :level)
+        level = rec[:level]
         return l.levels[level] >= l.levels[l.level]
     end
 

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -61,7 +61,7 @@ end
 
 function Memento.Filter(l::Logger)
     function level_filter(rec::Record)
-        level = rec[:level]
+        level = get(rec, :level)
 
         if haskey(l.levels, level)
             return l.levels[level] >= l.levels[l.level]

--- a/src/records.jl
+++ b/src/records.jl
@@ -2,26 +2,61 @@
 `Record`s are used to store information about a log event including the
 msg, date, level, stacktrace, etc. `Formatter`s use `Records` to format log
 message strings.
+
+TODO: Finish implementing `Record`s as specific associative types.
 """
-abstract Record
+abstract Record <: Associative
+
+type Attribute{T}
+    f::Function
+    x::Nullable{T}
+end
+
+Attribute(T::Type, f::Function) = Attribute(f, Nullable{T}())
+Attribute(x) = Attribute(typeof(x), () -> x)
+
+# Base.convert(::Type{Attribute}, val::Any) = Attribute(val)
+
+function Base.get(attr::Attribute)
+    if isnull(attr.x)
+        attr.x = Nullable(attr.f())
+    end
+
+    return get(attr.x)
+end
 
 "`keys(::Record)` returns all keys in the inner dict"
 Base.keys(rec::Record) = keys(rec.dict)
 
-"`getdict(::Record)` returns the inner dict of the record "
-getdict(rec::Record) = rec.dict
+function Base.copy{R<:Record}(rec::R)
+    new_rec = R()
+
+    for (key, val) in rec.dict
+        new_rec.dict[key] = val
+    end
+
+    return new_rec
+end
+
+function Base.Dict(rec::Record)
+    return map(keys(rec)) do key
+        key => get(rec.dict[key])
+    end |> Dict
+end
 
 """
 `getindex(::Record, key)` returns the item from the inner dict.
 If the value is a zero argument function it will be executed.
 """
-function Base.getindex(rec::Record, key)
-    if isa(rec.dict[key], Function)
-        return rec.dict[key]()
-    else
-        return rec.dict[key]
-    end
-end
+Base.getindex(rec::Record, key) = get(rec.dict[key])
+
+Base.setindex!(rec::Record, val::Attribute, key::Symbol) = rec.dict[key] = val
+
+Base.start(rec::Record) = start(rec.dict)
+
+Base.next(rec::Record, state) = next(rec.dict, state)
+
+Base.done(rec::Record, state) = done(rec.dict, state)
 
 """
 `DefaultRecord` wraps a `Dict{Symbol, Any}` which stores basic logging event
@@ -39,23 +74,58 @@ lookup: the top StackFrame
 stacktrace: a stacktrace
 """
 type DefaultRecord <: Record
-    dict::Dict{Symbol, Any}
+    dict::Dict{Symbol, Attribute}
 
-    function DefaultRecord(args::Dict)
-        trace = StackTraces.remove_frames!(
-            StackTraces.stacktrace(),
-            [:DefaultRecord, :log, Symbol("#log#22"), :info, :warn, :debug]
-        )
+    DefaultRecord() = new(Dict{Symbol, Attribute}())
+    DefaultRecord(args::Dict{Symbol, Any}) = new(default_attributes(args))
+end
 
-        new(Dict(
-            :date => round(now(), Base.Dates.Second),
-            :level => args[:level],
-            :levelnum => args[:levelnum],
-            :msg => args[:msg],
-            :name => args[:name],
-            :pid => myid(),
-            :lookup => isempty(trace) ? nothing : first(trace),
-            :stacktrace => trace,
-        ))
+function default_attributes(args::Dict{Symbol, Any})
+    time = now()
+    trace = Attribute(StackTrace, get_trace)
+
+    return Dict(
+        :date => Attribute(DateTime, () -> round(time, Base.Dates.Second)),
+        :level => Attribute(args[:level]),
+        :levelnum => Attribute(args[:levelnum]),
+        :msg => Attribute(AbstractString, get_msg(args[:msg])),
+        :name => Attribute(args[:name]),
+        :pid => Attribute(myid()),
+        :lookup => Attribute(StackFrame, get_lookup(trace)),
+        :stacktrace => trace,
+    )
+end
+
+function get_trace()
+    return StackTraces.remove_frames!(
+        StackTraces.stacktrace(),
+        [
+            :DefaultRecord,
+            :log,
+            Symbol("#log#22"),
+            :info,
+            :warn,
+            :debug,
+            :get_trace,
+            :emit,
+        ]
+    )
+end
+
+function get_lookup(trace::Attribute{StackTrace})
+    function inner_lookup()
+        if isempty(get(trace))
+            return nothing
+        else
+            return first(get(trace))
+        end
+    end
+end
+
+function get_msg(msg)
+    if isa(msg, AbstractString)
+        return () -> msg
+    else
+        return msg
     end
 end

--- a/src/records.jl
+++ b/src/records.jl
@@ -24,12 +24,11 @@ TODO: Finish implementing `Record`s as specific associative types.
 """
 abstract Record
 
-Base.get(rec::Record, attr::Symbol) = get(getfield(rec, attr))
-Base.getindex(rec::Record, attr::Symbol) = get(rec, attr)
+Base.getindex(rec::Record, attr::Symbol) = get(getfield(rec, attr))
 
 function Base.Dict(rec::Record)
     return map(fieldnames(rec)) do key
-        key => get(rec, key)
+        key => rec[key]
     end |> Dict
 end
 

--- a/src/records.jl
+++ b/src/records.jl
@@ -83,13 +83,8 @@ function get_trace()
 end
 
 function get_lookup(trace::Attribute{StackTrace})
-    function inner_lookup()
-        if isempty(get(trace))
-            return nothing
-        else
-            return first(get(trace))
-        end
-    end
+    inner() = isempty(get(trace)) ? nothing : first(get(trace))
+    return inner
 end
 
 function get_msg(msg)

--- a/src/records.jl
+++ b/src/records.jl
@@ -25,6 +25,7 @@ TODO: Finish implementing `Record`s as specific associative types.
 abstract Record
 
 Base.get(rec::Record, attr::Symbol) = get(getfield(rec, attr))
+Base.getindex(rec::Record, attr::Symbol) = get(rec, attr)
 
 function Base.Dict(rec::Record)
     return map(fieldnames(rec)) do key

--- a/src/records.jl
+++ b/src/records.jl
@@ -5,14 +5,23 @@ message strings.
 """
 abstract Record
 
+"`keys(::Record)` returns all keys in the inner dict"
+Base.keys(rec::Record) = keys(rec.dict)
+
 "`getdict(::Record)` returns the inner dict of the record "
 getdict(rec::Record) = rec.dict
 
-"`getindex(::Record, key)` returns the item from the inner dict"
-Base.getindex(rec::Record, key) = rec.dict[key]
-
-"`keys(::Record)` returns all keys in the inner dict"
-Base.keys(rec::Record) = keys(rec.dict)
+"""
+`getindex(::Record, key)` returns the item from the inner dict.
+If the value is a zero argument function it will be executed.
+"""
+function Base.getindex(rec::Record, key)
+    if isa(rec.dict[key], Function)
+        return rec.dict[key]()
+    else
+        return rec.dict[key]
+    end
+end
 
 """
 `DefaultRecord` wraps a `Dict{Symbol, Any}` which stores basic logging event

--- a/src/records.jl
+++ b/src/records.jl
@@ -1,11 +1,3 @@
-"""
-`Record`s are used to store information about a log event including the
-msg, date, level, stacktrace, etc. `Formatter`s use `Records` to format log
-message strings.
-
-TODO: Finish implementing `Record`s as specific associative types.
-"""
-abstract Record <: Associative
 
 type Attribute{T}
     f::Function
@@ -15,8 +7,6 @@ end
 Attribute(T::Type, f::Function) = Attribute(f, Nullable{T}())
 Attribute(x) = Attribute(typeof(x), () -> x)
 
-# Base.convert(::Type{Attribute}, val::Any) = Attribute(val)
-
 function Base.get(attr::Attribute)
     if isnull(attr.x)
         attr.x = Nullable(attr.f())
@@ -25,38 +15,23 @@ function Base.get(attr::Attribute)
     return get(attr.x)
 end
 
-"`keys(::Record)` returns all keys in the inner dict"
-Base.keys(rec::Record) = keys(rec.dict)
+"""
+`Record`s are used to store information about a log event including the
+msg, date, level, stacktrace, etc. `Formatter`s use `Records` to format log
+message strings.
 
-function Base.copy{R<:Record}(rec::R)
-    new_rec = R()
+TODO: Finish implementing `Record`s as specific associative types.
+"""
+abstract Record
 
-    for (key, val) in rec.dict
-        new_rec.dict[key] = val
-    end
-
-    return new_rec
-end
+Base.get(rec::Record, attr::Symbol) = get(getfield(rec, attr))
 
 function Base.Dict(rec::Record)
-    return map(keys(rec)) do key
-        key => get(rec.dict[key])
+    return map(fieldnames(rec)) do key
+        key => get(rec, key)
     end |> Dict
 end
 
-"""
-`getindex(::Record, key)` returns the item from the inner dict.
-If the value is a zero argument function it will be executed.
-"""
-Base.getindex(rec::Record, key) = get(rec.dict[key])
-
-Base.setindex!(rec::Record, val::Attribute, key::Symbol) = rec.dict[key] = val
-
-Base.start(rec::Record) = start(rec.dict)
-
-Base.next(rec::Record, state) = next(rec.dict, state)
-
-Base.done(rec::Record, state) = done(rec.dict, state)
 
 """
 `DefaultRecord` wraps a `Dict{Symbol, Any}` which stores basic logging event
@@ -73,26 +48,30 @@ pid: the pid of where the log event occured
 lookup: the top StackFrame
 stacktrace: a stacktrace
 """
-type DefaultRecord <: Record
-    dict::Dict{Symbol, Attribute}
-
-    DefaultRecord() = new(Dict{Symbol, Attribute}())
-    DefaultRecord(args::Dict{Symbol, Any}) = new(default_attributes(args))
+immutable DefaultRecord <: Record
+    date::Attribute
+    level::Attribute
+    levelnum::Attribute
+    msg::Attribute
+    name::Attribute
+    pid::Attribute
+    lookup::Attribute
+    stacktrace::Attribute
 end
 
-function default_attributes(args::Dict{Symbol, Any})
+function DefaultRecord(args::Dict{Symbol, Any})
     time = now()
     trace = Attribute(StackTrace, get_trace)
 
-    return Dict(
-        :date => Attribute(DateTime, () -> round(time, Base.Dates.Second)),
-        :level => Attribute(args[:level]),
-        :levelnum => Attribute(args[:levelnum]),
-        :msg => Attribute(AbstractString, get_msg(args[:msg])),
-        :name => Attribute(args[:name]),
-        :pid => Attribute(myid()),
-        :lookup => Attribute(StackFrame, get_lookup(trace)),
-        :stacktrace => trace,
+    DefaultRecord(
+        Attribute(DateTime, () -> round(time, Base.Dates.Second)),
+        Attribute(args[:level]),
+        Attribute(args[:levelnum]),
+        Attribute(AbstractString, get_msg(args[:msg])),
+        Attribute(args[:name]),
+        Attribute(myid()),
+        Attribute(StackFrame, get_lookup(trace)),
+        trace,
     )
 end
 

--- a/src/records.jl
+++ b/src/records.jl
@@ -76,19 +76,10 @@ function DefaultRecord(args::Dict{Symbol, Any})
 end
 
 function get_trace()
-    return StackTraces.remove_frames!(
-        StackTraces.stacktrace(),
-        [
-            :DefaultRecord,
-            :log,
-            Symbol("#log#22"),
-            :info,
-            :warn,
-            :debug,
-            :get_trace,
-            :emit,
-        ]
-    )
+    trace = StackTraces.stacktrace()
+    return filter!(trace) do frame
+        !in(frame, Memento)
+    end
 end
 
 function get_lookup(trace::Attribute{StackTrace})
@@ -107,4 +98,16 @@ function get_msg(msg)
     else
         return msg
     end
+end
+
+function Base.in(frame::StackFrame, filter_mod::Module)
+    finfo = frame.linfo
+    result = false
+
+    if !isnull(finfo)
+        frame_mod = get(finfo).def.module
+        result = module_name(frame_mod) === module_name(filter_mod)
+    end
+
+    return result
 end

--- a/test/benchmarks.jl
+++ b/test/benchmarks.jl
@@ -1,0 +1,65 @@
+# A utility script for running a comparison benchmark.
+
+using PkgBenchmark
+
+import BenchmarkTools:
+    BenchmarkGroup,
+    TrialJudgement,
+    prettydiff,
+    memory,
+    ratio,
+    isregression
+
+function flatten(group::BenchmarkGroup; prefix="")
+    results = Pair[]
+
+    for (name, val) in group.data
+        if isa(val, BenchmarkGroup)
+            append!(results, flatten(val; prefix="$prefix/$name"))
+        elseif isa(val, TrialJudgement)
+            push!(results, "$prefix/$name" => val)
+        end
+    end
+
+    return results
+end
+
+@testset "Benchmarks" begin
+    curr_commit = get(ENV, "MEMENTO_CURR_COMMIT", "16b620c")
+    base_commit = get(ENV, "MEMENTO_BASE_COMMIT", "be07e98")
+    result = judge(
+        "Memento",
+        curr_commit,
+        base_commit;
+        saveresults=false,
+        promptsave=false,
+        f=median,
+        judgekwargs=Dict(
+            :time_tolerance => 0.2,
+            :memory_tolerance => 0.2,
+        ),
+    )
+
+    flat_result = flatten(result["Memento"])
+
+    println("Benchmark, Time, Memory")
+    for element in flat_result
+        println(string(
+            element.first,
+            ", ",
+            prettydiff(time(ratio(element.second))),
+            " ( ",
+            time(element.second),
+            " )",
+            ", ",
+            prettydiff(memory(ratio(element.second))),
+            " ( ",
+            memory(element.second),
+            " )",
+        ))
+    end
+
+    for element in flat_result
+        @test !isregression(element.second)
+    end
+end

--- a/test/formatters.jl
+++ b/test/formatters.jl
@@ -1,7 +1,11 @@
 import Memento: Attribute
 
 type TestRecord <: Record
-    dict::Dict{Symbol, Attribute}
+    date::Attribute
+    level::Attribute
+    levelnum::Attribute
+    name::Attribute
+    msg::Attribute
 end
 
 @testset "Formatters" begin
@@ -11,20 +15,14 @@ end
 
     @testset "JsonFormatter" begin
         rec = TestRecord(
-            Dict{Symbol, Attribute}(
-                :date => Attribute(now()),
-                :level => Attribute("info"),
-                :levelnum => Attribute(20),
-                :name => Attribute("root"),
-                :msg => Attribute("blah"),
-            )
+            Attribute(now()),
+            Attribute("info"),
+            Attribute(20),
+            Attribute("root"),
+            Attribute("blah"),
         )
 
         fmt = JsonFormatter()
         @test format(fmt, rec) == json(Dict(rec))
-        ret = format(fmt, DefaultRecord(Dict(rec)))
-
-        @test contains(ret, "lookup")
-        @test contains(ret, "stacktrace")
     end
 end

--- a/test/formatters.jl
+++ b/test/formatters.jl
@@ -10,7 +10,24 @@ end
 
 @testset "Formatters" begin
     @testset "DefaultFormatter" begin
+        rec = DefaultRecord(Dict{Symbol, Any}(
+            :name => "Logger.example",
+            :level => :info,
+            :levelnum => 20,
+            :msg => "blah",
+        ))
 
+        fmt = DefaultFormatter("{lookup}|{msg}|{stacktrace}")
+        result = format(fmt, rec)
+        parts = split(result, "|")
+        @test length(parts) == 3
+        @test parts[2] == "blah"
+        @test length(parts[1]) > 0
+        @test length(parts[3]) > 0
+        @test contains(parts[3], "formatters")
+        @test !contains(parts[3], "get_trace")
+        @test !contains(parts[3], "DefaultRecord")
+        @test !contains(parts[3], "get")
     end
 
     @testset "JsonFormatter" begin

--- a/test/formatters.jl
+++ b/test/formatters.jl
@@ -1,5 +1,7 @@
+import Memento: Attribute
+
 type TestRecord <: Record
-    dict::Dict{Symbol, Any}
+    dict::Dict{Symbol, Attribute}
 end
 
 @testset "Formatters" begin
@@ -9,18 +11,18 @@ end
 
     @testset "JsonFormatter" begin
         rec = TestRecord(
-            Dict{Symbol, Any}(
-                :date => now(),
-                :level => "info",
-                :levelnum => 20,
-                :name => "root",
-                :msg => "blah"
+            Dict{Symbol, Attribute}(
+                :date => Attribute(now()),
+                :level => Attribute("info"),
+                :levelnum => Attribute(20),
+                :name => Attribute("root"),
+                :msg => Attribute("blah"),
             )
         )
 
         fmt = JsonFormatter()
-        @test format(fmt, rec) == json(rec.dict)
-        ret = format(fmt, DefaultRecord(rec.dict))
+        @test format(fmt, rec) == json(Dict(rec))
+        ret = format(fmt, DefaultRecord(Dict(rec)))
 
         @test contains(ret, "lookup")
         @test contains(ret, "stacktrace")

--- a/test/handlers.jl
+++ b/test/handlers.jl
@@ -165,5 +165,42 @@
                 close(io)
             end
         end
+
+        @testset "Level Filter" begin
+            io = IOBuffer()
+
+            try
+                handler = DefaultHandler(
+                    io, DefaultFormatter(FMT_STR)
+                )
+
+                logger = Logger(
+                    "DefaultHandler.sample_io",
+                    Dict("Buffer" => handler),
+                    "info",
+                    LEVELS,
+                    DefaultRecord,
+                    true
+                )
+
+                @test logger.name == "DefaultHandler.sample_io"
+                @test logger.level == "info"
+
+                msg = "It works!"
+                Memento.info(logger, msg)
+                @test contains(takebuf_string(io), "[info]:$(logger.name) - $msg")
+
+                # Filter out log messages < LEVELS["warn"]
+                add_filter(
+                    handler,
+                    Filter((rec) -> rec[:levelnum] >= LEVELS["warn"])
+                )
+
+                Memento.info(logger, "This shouldn't get logged")
+                @test isempty(takebuf_string(io))
+            finally
+                close(io)
+            end
+        end
     end
 end

--- a/test/handlers.jl
+++ b/test/handlers.jl
@@ -2,6 +2,7 @@
     FMT_STR = "[{level}]:{name} - {msg}"
 
     LEVELS = Dict(
+        "not_set" => 0,
         "debug" => 10,
         "info" => 20,
         "warn" => 30,
@@ -191,10 +192,11 @@
                 @test contains(takebuf_string(io), "[info]:$(logger.name) - $msg")
 
                 # Filter out log messages < LEVELS["warn"]
-                add_filter(
-                    handler,
-                    Filter((rec) -> rec[:levelnum] >= LEVELS["warn"])
-                )
+                set_level(handler, "warn")
+                # add_filter(
+                #     handler,
+                #     Filter((rec) -> rec[:levelnum] >= LEVELS["warn"])
+                # )
 
                 Memento.info(logger, "This shouldn't get logged")
                 @test isempty(takebuf_string(io))

--- a/test/io.jl
+++ b/test/io.jl
@@ -4,6 +4,7 @@ using Base.Test
 @testset "IO" begin
     @testset "FileRoller" begin
         levels = Dict(
+            "not_set" => 0,
             "debug" => 10,
             "info" => 20,
             "warn" => 30,

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -115,8 +115,8 @@
             @test isempty(takebuf_string(io))
 
             msg = "Something went very wrong"
-            log(msg_func(msg), logger, "fubar")
-            @test contains(takebuf_string(io), "[fubar]:Logger.example - $msg")
+            @test_throws ErrorException error(msg_func(msg), logger)
+            @test contains(takebuf_string(io), "[error]:Logger.example - $msg")
 
             new_logger = Logger("new_logger")
         finally

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -9,7 +9,7 @@
         "error" => 40,
     )
 
-    @testset "Example" begin
+    @testset "Simple" begin
         io = IOBuffer()
 
         try
@@ -55,6 +55,67 @@
 
             msg = "Something went very wrong"
             log(logger, "fubar", msg)
+            @test contains(takebuf_string(io), "[fubar]:Logger.example - $msg")
+
+            new_logger = Logger("new_logger")
+        finally
+            close(io)
+        end
+    end
+    @testset "Lazy Messages" begin
+        # A test utility function that gives
+        # us a function to pass to the log method
+        # which will execute only if the message is
+        # evaluated.
+        function msg_func(msg)
+            inner() = msg
+            return inner
+        end
+
+        io = IOBuffer()
+
+        try
+            handler = DefaultHandler(
+                io, DefaultFormatter(FMT_STR)
+            )
+
+            logger = Logger(
+                "Logger.example",
+                Dict("Buffer" => handler),
+                "error",
+                LEVELS,
+                DefaultRecord,
+                true
+            )
+
+            @test logger.name == "Logger.example"
+            @test logger.level == "error"
+            @test length(get_handlers(logger)) == 1
+
+            add_handler(logger, DefaultHandler(tempname()), "filehandler")
+            @test length(get_handlers(logger)) == 2
+
+            remove_handler(logger, "filehandler")
+            @test length(get_handlers(logger)) == 1
+
+            set_level(logger, "info")
+            @test logger.level == "info"
+
+            set_record(logger, DefaultRecord)
+            add_level(logger, "fubar", 50)
+
+            show(io, logger)
+            @test contains(takebuf_string(io), "Logger(Logger.example)")
+
+            msg = "It works!"
+            Memento.info(msg_func(msg), logger)
+            @test contains(takebuf_string(io), "[info]:Logger.example - $msg")
+
+            Memento.debug(msg_func("This shouldn't get logged"), logger)
+            @test isempty(takebuf_string(io))
+
+            msg = "Something went very wrong"
+            log(msg_func(msg), logger, "fubar")
             @test contains(takebuf_string(io), "[fubar]:Logger.example - $msg")
 
             new_logger = Logger("new_logger")

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -2,6 +2,7 @@
     FMT_STR = "[{level}]:{name} - {msg}"
 
     LEVELS = Dict(
+        "not_set" => 0,
         "debug" => 10,
         "info" => 20,
         "warn" => 30,

--- a/test/records.jl
+++ b/test/records.jl
@@ -1,5 +1,17 @@
 @testset "Records" begin
     @testset "DefaultRecord" begin
+        rec = DefaultRecord(Dict{Symbol, Any}(
+            :name => "Logger.example",
+            :level => :info,
+            :levelnum => 20,
+            :msg => "blah",
+        ))
 
+        @test rec[:date] == get(rec, :date)
+        @test rec[:date] == get(rec.date)
+        @test get(rec.date) == get(rec.date.x)
+
+        dict = Dict(rec)
+        @test rec[:date] == dict[:date]
     end
 end

--- a/test/records.jl
+++ b/test/records.jl
@@ -7,7 +7,6 @@
             :msg => "blah",
         ))
 
-        @test rec[:date] == get(rec, :date)
         @test rec[:date] == get(rec.date)
         @test get(rec.date) == get(rec.date.x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,6 @@
 using Base.Test
+using Memento
+using JSON
 
 files = [
     "records.jl",
@@ -7,99 +9,98 @@ files = [
     "loggers.jl",
 ]
 
-opts = Base.JLOptions()
-
-if isdefined(opts, :use_compilecache) && Bool(opts.use_compilecache)
-    info("test/io.jl not included as they require mocking which requires that compilecache is disabled.")
-    info("To include test/io.jl tests run with `--compilecache=no`")
-    push!(files, "concurrency.jl")
-else
-    info("test/concurrency.jl not included as they require that compilecache is enabled.")
-    info("To include test/concurrency.jl tests run without `--compilecache=no`")
-    using Mocking
-    Mocking.enable()
-    push!(files, "io.jl")
-end
-
-
-using Memento
-using JSON
-
-cd(dirname(@__FILE__))
-
-
-@testset "Logging" begin
-    @testset "Sample Usage" begin
-        basic_config("info"; fmt="[{date} | {level} | {name}]: {msg}", colorized=false)
-        logger1 = get_logger(current_module())
-        debug(logger1, "Something that won't get logged.")
-        info(logger1, "Something you might want to know.")
-        warn(logger1, "This might cause an error.")
-        warn(logger1, ErrorException("A caught exception that we want to log as a warning."))
-        @test_throws ErrorException error(logger1, "Something that should throw an error.")
-        @test_throws ErrorException error(logger1, ErrorException("A caught exception that we should log and rethrow"))
-        logger2 = get_logger("Pkg.Foo.Bar")
-    end
-
-    @testset "Logger Hierarchy" begin
-        Memento.reset!()
-        foo = get_logger("Foo")
-        bar = get_logger("Foo.Bar")
-        baz = get_logger("Foo.Bar.Baz")
-        car = get_logger("Foo.Car")
-
-        for l in (foo, bar, baz, car)
-            @test !is_set(l)
-            @test length(get_handlers(l)) == 0
-        end
-
-        io = IOBuffer()
-
-        try
-            set_level(get_logger(), "info")
-            add_handler(
-                get_logger(),
-                DefaultHandler(io, DefaultFormatter("{name} - {level}: {msg}")),
-                "io"
-            )
-
-            msg = "This should propagate to the root logger."
-            warn(baz, msg)
-            result = takebuf_string(io)
-            expected = "Foo.Bar.Baz - warn: $msg"
-            @test contains(result, expected)
-
-            set_level(baz, "debug")
-            add_handler(
-                baz,
-                DefaultHandler(io, DefaultFormatter("{name} - {level}: {msg}")),
-                "io"
-            )
-
-            msg = "Message"
-            warn(baz, msg)
-            str = takebuf_string(io)
-
-            # The message should be written twice for "root" and "Foo.Bar.Baz"
-            @test length(str) > length("Foo.Bar.Baz - warn: $msg") * 2
-
-            debug(baz, msg)
-            # Test that the "root" logger won't print anything bug the baz logger will
-            # because of their respective logging levels
-            @test contains(takebuf_string(io), "Foo.Bar.Baz - debug: $msg")
-
-            info(car, msg)
-            # the Foo.Car logger should still be unaffected.
-            @test contains(takebuf_string(io), "Foo.Car - info: $msg")
-        finally
-            close(io)
-        end
-    end
-end
-
-
-# Test files should assume the global _loggers has been reset
-for file in files
+if haskey(ENV, "MEMENTO_BENCHMARK")
     Memento.reset!()
-    include(abspath(file))
+    include(abspath("benchmarks.jl"))
+else
+    opts = Base.JLOptions()
+    if isdefined(opts, :use_compilecache) && Bool(opts.use_compilecache)
+        info("test/io.jl not included as they require mocking which requires that compilecache is disabled.")
+        info("To include test/io.jl tests run with `--compilecache=no`")
+        push!(files, "concurrency.jl")
+    else
+        info("test/concurrency.jl not included as they require that compilecache is enabled.")
+        info("To include test/concurrency.jl tests run without `--compilecache=no`")
+        using Mocking
+        Mocking.enable()
+        push!(files, "io.jl")
+    end
+
+    cd(dirname(@__FILE__))
+
+    @testset "Logging" begin
+        @testset "Sample Usage" begin
+            basic_config("info"; fmt="[{date} | {level} | {name}]: {msg}", colorized=false)
+            logger1 = get_logger(current_module())
+            debug(logger1, "Something that won't get logged.")
+            info(logger1, "Something you might want to know.")
+            warn(logger1, "This might cause an error.")
+            warn(logger1, ErrorException("A caught exception that we want to log as a warning."))
+            @test_throws ErrorException error(logger1, "Something that should throw an error.")
+            @test_throws ErrorException error(logger1, ErrorException("A caught exception that we should log and rethrow"))
+            logger2 = get_logger("Pkg.Foo.Bar")
+        end
+
+        @testset "Logger Hierarchy" begin
+            Memento.reset!()
+            foo = get_logger("Foo")
+            bar = get_logger("Foo.Bar")
+            baz = get_logger("Foo.Bar.Baz")
+            car = get_logger("Foo.Car")
+
+            for l in (foo, bar, baz, car)
+                @test !is_set(l)
+                @test length(get_handlers(l)) == 0
+            end
+
+            io = IOBuffer()
+
+            try
+                set_level(get_logger(), "info")
+                add_handler(
+                    get_logger(),
+                    DefaultHandler(io, DefaultFormatter("{name} - {level}: {msg}")),
+                    "io"
+                )
+
+                msg = "This should propagate to the root logger."
+                warn(baz, msg)
+                result = takebuf_string(io)
+                expected = "Foo.Bar.Baz - warn: $msg"
+                @test contains(result, expected)
+
+                set_level(baz, "debug")
+                add_handler(
+                    baz,
+                    DefaultHandler(io, DefaultFormatter("{name} - {level}: {msg}")),
+                    "io"
+                )
+
+                msg = "Message"
+                warn(baz, msg)
+                str = takebuf_string(io)
+
+                # The message should be written twice for "root" and "Foo.Bar.Baz"
+                @test length(str) > length("Foo.Bar.Baz - warn: $msg") * 2
+
+                debug(baz, msg)
+                # Test that the "root" logger won't print anything bug the baz logger will
+                # because of their respective logging levels
+                @test contains(takebuf_string(io), "Foo.Bar.Baz - debug: $msg")
+
+                info(car, msg)
+                # the Foo.Car logger should still be unaffected.
+                @test contains(takebuf_string(io), "Foo.Car - info: $msg")
+            finally
+                close(io)
+            end
+        end
+    end
+
+
+    # Test files should assume the global _loggers has been reset
+    for file in files
+        Memento.reset!()
+        include(abspath(file))
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,4 @@
 using Base.Test
-using Memento
-using JSON
 
 files = [
     "records.jl",
@@ -9,98 +7,100 @@ files = [
     "loggers.jl",
 ]
 
-if haskey(ENV, "MEMENTO_BENCHMARK")
-    Memento.reset!()
-    include(abspath("benchmarks.jl"))
+opts = Base.JLOptions()
+if isdefined(opts, :use_compilecache) && Bool(opts.use_compilecache)
+    info("test/io.jl not included as they require mocking which requires that compilecache is disabled.")
+    info("To include test/io.jl tests run with `--compilecache=no`")
+    push!(files, "concurrency.jl")
 else
-    opts = Base.JLOptions()
-    if isdefined(opts, :use_compilecache) && Bool(opts.use_compilecache)
-        info("test/io.jl not included as they require mocking which requires that compilecache is disabled.")
-        info("To include test/io.jl tests run with `--compilecache=no`")
-        push!(files, "concurrency.jl")
-    else
-        info("test/concurrency.jl not included as they require that compilecache is enabled.")
-        info("To include test/concurrency.jl tests run without `--compilecache=no`")
-        using Mocking
-        Mocking.enable()
-        push!(files, "io.jl")
+    info("test/concurrency.jl not included as they require that compilecache is enabled.")
+    info("To include test/concurrency.jl tests run without `--compilecache=no`")
+    using Mocking
+    Mocking.enable()
+    push!(files, "io.jl")
+end
+
+if haskey(ENV, "MEMENTO_BENCHMARK")
+    files = ["benchmarks.jl"]
+end
+
+using Memento
+using JSON
+
+cd(dirname(@__FILE__))
+
+@testset "Logging" begin
+    @testset "Sample Usage" begin
+        basic_config("info"; fmt="[{date} | {level} | {name}]: {msg}", colorized=false)
+        logger1 = get_logger(current_module())
+        debug(logger1, "Something that won't get logged.")
+        info(logger1, "Something you might want to know.")
+        warn(logger1, "This might cause an error.")
+        warn(logger1, ErrorException("A caught exception that we want to log as a warning."))
+        @test_throws ErrorException error(logger1, "Something that should throw an error.")
+        @test_throws ErrorException error(logger1, ErrorException("A caught exception that we should log and rethrow"))
+        logger2 = get_logger("Pkg.Foo.Bar")
     end
 
-    cd(dirname(@__FILE__))
-
-    @testset "Logging" begin
-        @testset "Sample Usage" begin
-            basic_config("info"; fmt="[{date} | {level} | {name}]: {msg}", colorized=false)
-            logger1 = get_logger(current_module())
-            debug(logger1, "Something that won't get logged.")
-            info(logger1, "Something you might want to know.")
-            warn(logger1, "This might cause an error.")
-            warn(logger1, ErrorException("A caught exception that we want to log as a warning."))
-            @test_throws ErrorException error(logger1, "Something that should throw an error.")
-            @test_throws ErrorException error(logger1, ErrorException("A caught exception that we should log and rethrow"))
-            logger2 = get_logger("Pkg.Foo.Bar")
-        end
-
-        @testset "Logger Hierarchy" begin
-            Memento.reset!()
-            foo = get_logger("Foo")
-            bar = get_logger("Foo.Bar")
-            baz = get_logger("Foo.Bar.Baz")
-            car = get_logger("Foo.Car")
-
-            for l in (foo, bar, baz, car)
-                @test !is_set(l)
-                @test length(get_handlers(l)) == 0
-            end
-
-            io = IOBuffer()
-
-            try
-                set_level(get_logger(), "info")
-                add_handler(
-                    get_logger(),
-                    DefaultHandler(io, DefaultFormatter("{name} - {level}: {msg}")),
-                    "io"
-                )
-
-                msg = "This should propagate to the root logger."
-                warn(baz, msg)
-                result = takebuf_string(io)
-                expected = "Foo.Bar.Baz - warn: $msg"
-                @test contains(result, expected)
-
-                set_level(baz, "debug")
-                add_handler(
-                    baz,
-                    DefaultHandler(io, DefaultFormatter("{name} - {level}: {msg}")),
-                    "io"
-                )
-
-                msg = "Message"
-                warn(baz, msg)
-                str = takebuf_string(io)
-
-                # The message should be written twice for "root" and "Foo.Bar.Baz"
-                @test length(str) > length("Foo.Bar.Baz - warn: $msg") * 2
-
-                debug(baz, msg)
-                # Test that the "root" logger won't print anything bug the baz logger will
-                # because of their respective logging levels
-                @test contains(takebuf_string(io), "Foo.Bar.Baz - debug: $msg")
-
-                info(car, msg)
-                # the Foo.Car logger should still be unaffected.
-                @test contains(takebuf_string(io), "Foo.Car - info: $msg")
-            finally
-                close(io)
-            end
-        end
-    end
-
-
-    # Test files should assume the global _loggers has been reset
-    for file in files
+    @testset "Logger Hierarchy" begin
         Memento.reset!()
-        include(abspath(file))
+        foo = get_logger("Foo")
+        bar = get_logger("Foo.Bar")
+        baz = get_logger("Foo.Bar.Baz")
+        car = get_logger("Foo.Car")
+
+        for l in (foo, bar, baz, car)
+            @test !is_set(l)
+            @test length(get_handlers(l)) == 0
+        end
+
+        io = IOBuffer()
+
+        try
+            set_level(get_logger(), "info")
+            add_handler(
+                get_logger(),
+                DefaultHandler(io, DefaultFormatter("{name} - {level}: {msg}")),
+                "io"
+            )
+
+            msg = "This should propagate to the root logger."
+            warn(baz, msg)
+            result = takebuf_string(io)
+            expected = "Foo.Bar.Baz - warn: $msg"
+            @test contains(result, expected)
+
+            set_level(baz, "debug")
+            add_handler(
+                baz,
+                DefaultHandler(io, DefaultFormatter("{name} - {level}: {msg}")),
+                "io"
+            )
+
+            msg = "Message"
+            warn(baz, msg)
+            str = takebuf_string(io)
+
+            # The message should be written twice for "root" and "Foo.Bar.Baz"
+            @test length(str) > length("Foo.Bar.Baz - warn: $msg") * 2
+
+            debug(baz, msg)
+            # Test that the "root" logger won't print anything bug the baz logger will
+            # because of their respective logging levels
+            @test contains(takebuf_string(io), "Foo.Bar.Baz - debug: $msg")
+
+            info(car, msg)
+            # the Foo.Car logger should still be unaffected.
+            @test contains(takebuf_string(io), "Foo.Car - info: $msg")
+        finally
+            close(io)
+        end
     end
+end
+
+
+# Test files should assume the global _loggers has been reset
+for file in files
+    Memento.reset!()
+    include(abspath(file))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,7 +65,9 @@ cd(dirname(@__FILE__))
 
             msg = "This should propagate to the root logger."
             warn(baz, msg)
-            @test contains(takebuf_string(io), "Foo.Bar.Baz - warn: $msg")
+            result = takebuf_string(io)
+            expected = "Foo.Bar.Baz - warn: $msg"
+            @test contains(result, expected)
 
             set_level(baz, "debug")
             add_handler(


### PR DESCRIPTION
Includes:

* Generic filters with defaults for `Logger`s and `Handler`s
* Reimplementation of `Records` to perform lazy evaluation of record `Attribute`s
* Order of magnitude speed up in memory usage and cpu time for logging simple messages without stacktraces.
* Ability to provide a `Function` instead of a `String` for a message to be logged, which is useful if creating the message string is expensive if no `Handler` `emit`s the log record.