### PR TITLE
Initialize _loggers at compile time

### DIFF
--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -30,8 +30,6 @@ const global _log_levels = Dict{AbstractString, Int}(
     "emergency" => 70
 )
 
-global _loggers
-
 include("io.jl")
 include("records.jl")
 include("filters.jl")
@@ -39,10 +37,8 @@ include("formatters.jl")
 include("handlers.jl")
 include("loggers.jl")
 
-function __init__()
-    global _loggers = Dict{AbstractString, Logger}(
-        "root" => Logger("root"),
-    )
-end
+const global _loggers = Dict{AbstractString, Logger}(
+    "root" => Logger("root"),
+)
 
 end

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -133,7 +133,8 @@ without any handlers.
 """
 function reset!()
     empty!(_loggers)
-    Memento.__init__()
+    _loggers["root"] = Logger("root")
+    nothing
 end
 
 """


### PR DESCRIPTION
When using pre-compilation and Memento together packages would have to place their `logger = get_logger(current_module())` within an `__init__` function. This code revises `_loggers` to be initialized at compile time instead of at runtime which removes the need to place `logger = ...` within an `__init__`.

It appears the original reason this was being done at runtime was: https://github.com/WestleyArgentum/Lumberjack.jl/pull/25