### PR TITLE
Fixed incorrect exception type on `error(logger, exc)`.

### DIFF
--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -359,7 +359,8 @@ for key in keys(_log_levels)
                 end
 
                 function $level(logger::Logger, exc::Exception)
-                    $level(logger, sprint(io->showerror(io,exc)))
+                    log(logger, $key, sprint(io -> showerror(io, exc)))
+                    throw(exc)
                 end
             end
             f = eval(level)

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -1,3 +1,7 @@
+immutable TestError <: Exception
+    msg
+end
+
 @testset "Loggers" begin
     FMT_STR = "[{level}]:{name} - {msg}"
 
@@ -52,6 +56,9 @@
 
             Memento.debug(logger, "This shouldn't get logged")
             @test isempty(takebuf_string(io))
+
+            @test_throws TestError Memento.error(logger, TestError("I failed."))
+            @test contains(takebuf_string(io), "I failed")
 
             msg = "Something went very wrong"
             log(logger, "fubar", msg)


### PR DESCRIPTION
`error(logger, exc)` shouldn't call `error(logger, sprint(io -> showerror(io, exc)))` because this will cause the error message to be wrapped in an `ErrorException` rather than throwing whatever `Exception` is being passed in. Added a simple test to check this in the future. 