### PR TITLE
Fixed deprecation warnings.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.5
-
+Compat 0.17.0
 JSON 0.8
 Mocking 0.3

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -1,6 +1,7 @@
 module Memento
 
 using Mocking
+using Compat
 
 import Base: show, info, warn, error, log
 

--- a/src/formatters.jl
+++ b/src/formatters.jl
@@ -7,7 +7,7 @@ A `Formatter` must implement a `format(::Formatter, ::Record)` method
 which takes a `Record` and returns a `String` representation of the
 log `Record`.
 """
-abstract Formatter
+@compat abstract type Formatter end
 
 const DEFAULT_FMT_STRING = "[{level} | {name}]: {msg}"
 

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -9,7 +9,7 @@ method.
 NOTE: Handlers can useful if you need to special case logging behaviour
 based on the `Formatter`, `IO` and/or `Record` types.
 """
-abstract Handler{F<:Formatter, O<:IO}
+@compat abstract type Handler{F<:Formatter, O<:IO} end
 
 function Memento.Filter(h::Handler)
     function level_filter(rec::Record)

--- a/src/records.jl
+++ b/src/records.jl
@@ -51,7 +51,7 @@ message strings.
 NOTE: you should access `Attribute`s in a `Record` by using `getindex` (ie: record[:msg])
 as this will correctly extract the value from the `Attribute` container.
 """
-abstract Record
+@compat abstract type Record end
 
 Base.getindex(rec::Record, attr::Symbol) = get(getfield(rec, attr))
 

--- a/test/concurrency.jl
+++ b/test/concurrency.jl
@@ -16,7 +16,7 @@
             )
 
             asyncmap(x -> warn(get_logger(), "message"), 1:10)
-            all_msgs = split(takebuf_string(io), '\n')
+            all_msgs = split(String(take!(io)), '\n')
 
             @test !isempty(all_msgs)
             @test all(m -> m == all_msgs[1], all_msgs[2:end-1])

--- a/test/handlers.jl
+++ b/test/handlers.jl
@@ -33,14 +33,14 @@
 
                 msg = "It works!"
                 Memento.info(logger, msg)
-                @test contains(takebuf_string(io), "[info]:$(logger.name) - $msg")
+                @test contains(String(take!(io)), "[info]:$(logger.name) - $msg")
 
                 Memento.debug(logger, "This shouldn't get logged")
-                @test isempty(takebuf_string(io))
+                @test isempty(String(take!(io)))
 
                 msg = "Something went very wrong"
                 log(logger, "fubar", msg)
-                @test contains(takebuf_string(io), "[fubar]:$(logger.name) - $msg")
+                @test contains(String(take!(io)), "[fubar]:$(logger.name) - $msg")
             finally
                 close(io)
             end
@@ -79,7 +79,7 @@
                 handler1 = DefaultHandler(io)
 
                 @test handler1.fmt.fmt_str == Memento.DEFAULT_FMT_STRING
-                @test isempty(takebuf_string(handler1.io))
+                @test isempty(String(take!(handler1.io)))
                 @test !(handler1.opts[:is_colorized])
 
                 handler2 = DefaultHandler(
@@ -154,14 +154,14 @@
 
                 msg = "It works!"
                 Memento.info(logger, msg)
-                @test contains(takebuf_string(io), "[info]:$(logger.name) - $msg")
+                @test contains(String(take!(io)), "[info]:$(logger.name) - $msg")
 
                 Memento.debug(logger, "This shouldn't get logged")
-                @test isempty(takebuf_string(io))
+                @test isempty(String(take!(io)))
 
                 msg = "Something went very wrong"
                 log(logger, "fubar", msg)
-                @test contains(takebuf_string(io), "[fubar]:$(logger.name) - $msg")
+                @test contains(String(take!(io)), "[fubar]:$(logger.name) - $msg")
             finally
                 close(io)
             end
@@ -189,7 +189,7 @@
 
                 msg = "It works!"
                 Memento.info(logger, msg)
-                @test contains(takebuf_string(io), "[info]:$(logger.name) - $msg")
+                @test contains(String(take!(io)), "[info]:$(logger.name) - $msg")
 
                 # Filter out log messages < LEVELS["warn"]
                 set_level(handler, "warn")
@@ -199,7 +199,7 @@
                 # )
 
                 Memento.info(logger, "This shouldn't get logged")
-                @test isempty(takebuf_string(io))
+                @test isempty(String(take!(io)))
             finally
                 close(io)
             end

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -48,21 +48,21 @@ end
             add_level(logger, "fubar", 50)
 
             show(io, logger)
-            @test contains(takebuf_string(io), "Logger(Logger.example)")
+            @test contains(String(take!(io)), "Logger(Logger.example)")
 
             msg = "It works!"
             Memento.info(logger, msg)
-            @test contains(takebuf_string(io), "[info]:Logger.example - $msg")
+            @test contains(String(take!(io)), "[info]:Logger.example - $msg")
 
             Memento.debug(logger, "This shouldn't get logged")
-            @test isempty(takebuf_string(io))
+            @test isempty(String(take!(io)))
 
             @test_throws TestError Memento.error(logger, TestError("I failed."))
-            @test contains(takebuf_string(io), "I failed")
+            @test contains(String(take!(io)), "I failed")
 
             msg = "Something went very wrong"
             log(logger, "fubar", msg)
-            @test contains(takebuf_string(io), "[fubar]:Logger.example - $msg")
+            @test contains(String(take!(io)), "[fubar]:Logger.example - $msg")
 
             new_logger = Logger("new_logger")
         finally
@@ -112,18 +112,18 @@ end
             add_level(logger, "fubar", 50)
 
             show(io, logger)
-            @test contains(takebuf_string(io), "Logger(Logger.example)")
+            @test contains(String(take!(io)), "Logger(Logger.example)")
 
             msg = "It works!"
             Memento.info(msg_func(msg), logger)
-            @test contains(takebuf_string(io), "[info]:Logger.example - $msg")
+            @test contains(String(take!(io)), "[info]:Logger.example - $msg")
 
             Memento.debug(msg_func("This shouldn't get logged"), logger)
-            @test isempty(takebuf_string(io))
+            @test isempty(String(take!(io)))
 
             msg = "Something went very wrong"
             @test_throws ErrorException error(msg_func(msg), logger)
-            @test contains(takebuf_string(io), "[error]:Logger.example - $msg")
+            @test contains(String(take!(io)), "[error]:Logger.example - $msg")
 
             new_logger = Logger("new_logger")
         finally

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,7 +66,7 @@ cd(dirname(@__FILE__))
 
             msg = "This should propagate to the root logger."
             warn(baz, msg)
-            result = takebuf_string(io)
+            result = String(take!(io))
             expected = "Foo.Bar.Baz - warn: $msg"
             @test contains(result, expected)
 
@@ -79,7 +79,7 @@ cd(dirname(@__FILE__))
 
             msg = "Message"
             warn(baz, msg)
-            str = takebuf_string(io)
+            str = String(take!(io))
 
             # The message should be written twice for "root" and "Foo.Bar.Baz"
             @test length(str) > length("Foo.Bar.Baz - warn: $msg") * 2
@@ -87,11 +87,11 @@ cd(dirname(@__FILE__))
             debug(baz, msg)
             # Test that the "root" logger won't print anything bug the baz logger will
             # because of their respective logging levels
-            @test contains(takebuf_string(io), "Foo.Bar.Baz - debug: $msg")
+            @test contains(String(take!(io)), "Foo.Bar.Baz - debug: $msg")
 
             info(car, msg)
             # the Foo.Car logger should still be unaffected.
-            @test contains(takebuf_string(io), "Foo.Car - info: $msg")
+            @test contains(String(take!(io)), "Foo.Car - info: $msg")
         finally
             close(io)
         end


### PR DESCRIPTION
Uses Compat for `abstract type ... end` and `String(take!(io))` syntax in 0.6.