### PR TITLE
Make functions take and print to IO

### DIFF
--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -355,7 +355,7 @@ for key in keys(_log_levels)
 
                 function $level(msg::Function, logger::Logger)
                     log(msg, logger, $key)
-                    throw(ErrorException(msg()))
+                    throw(ErrorException(sprint(msg)))
                 end
 
                 function $level(logger::Logger, exc::Exception)

--- a/src/records.jl
+++ b/src/records.jl
@@ -148,17 +148,26 @@ function get_lookup(trace::Attribute{StackTrace})
 end
 
 """
-    get_msg(msg) -> Function
+    get_msg(msg::AbstractString) -> Function
 
-Wraps `msg` in a function if it is a String.
+Wraps `msg` in a 0-argument function if it is an `AbstractString`, for use in a `Record`.
 """
-function get_msg(msg)
-    if isa(msg, AbstractString)
-        return () -> msg
-    else
-        return msg
-    end
-end
+get_msg(msg::AbstractString) = () -> msg
+
+"""
+    get_msg(msg::Function) -> Function
+
+Accepts a 1-argument function `msg` which accepts and prints to an `IO` object.
+Wraps `msg` in a 0-argument function which calls `sprint`.
+"""
+get_msg(msg::Function) = () -> sprint(msg)
+
+"""
+    get_msg(msg::T) -> T
+
+Returns `msg` as a generic fallback.
+"""
+get_msg(msg) = msg
 
 """
     from(frame::StackFrame, filter_mod::Module) -> Bool

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -75,7 +75,7 @@ end
         # which will execute only if the message is
         # evaluated.
         function msg_func(msg)
-            inner() = msg
+            inner(io) = print(io, msg)
             return inner
         end
 


### PR DESCRIPTION
Previously you could call logging functions like:

```julia
username = "Rory"

error(LOGGER) do
    string("Hello, ", username)
end
```

which take no arguments and return strings. The main use case for this is to delay expensive computation until the log record is actually handled. Now, you would do this:

```julia
username = "Rory"

error(LOGGER) do io
    print(io, "Hello, ")
    print(io, username)
end
```

This represents a breaking change and would require a new major release.