### PR TITLE
Use better defaults

### DIFF
--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -8,7 +8,7 @@ using Compat
 import Base: show, info, warn, error, log
 
 export log, debug, info, notice, warn, error, critical, alert, emergency,
-       is_set, is_root, set_level, add_level, set_record, add_filter,
+       is_set, is_root, get_level, set_level, add_level, set_record, add_filter,
        add_handler, remove_handler, remove_handlers, emit,
        get_logger, get_handlers, format,
 

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -46,4 +46,8 @@ const global _loggers = Dict{AbstractString, Logger}(
     "root" => Logger("root"),
 )
 
+function __init__()
+    Memento.config("warn")
+end
+
 end

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -29,6 +29,7 @@ type Logger
     function Logger(name::AbstractString, handlers::Dict, level::AbstractString,
                     levels::Dict, record::Type, propagate::Bool)
         @assert haskey(levels, "not_set")
+        @assert haskey(levels, DEFAULT_LOG_LEVEL)
 
         logger = new(
             name,
@@ -51,7 +52,7 @@ type Logger
     end
 end
 
-function Logger{R<:Record}(name; level="not_set", levels=_log_levels,
+function Logger{R<:Record}(name; level=DEFAULT_LOG_LEVEL, levels=_log_levels,
                 record::Type{R}=DefaultRecord, propagate=true)
     logger = Logger(
         name,
@@ -66,7 +67,7 @@ end
 function Memento.Filter(l::Logger)
     function level_filter(rec::Record)
         level = rec[:level]
-        return l.levels[level] >= l.levels[l.level]
+        return haskey(l.levels, level) && l.levels[level] >= l.levels[l.level]
     end
 
     Memento.Filter(level_filter)
@@ -87,11 +88,18 @@ Returns true if `logger.name`is "root" or ""
 is_root(logger::Logger) = logger.name == "root" || logger.name == ""
 
 """
-    is_set(:Logger)
+    is_set(::Logger)
 
 Returns true or false as to whether the logger is set. (ie: logger.level != "not_set")
 """
 is_set(logger::Logger) = logger.level != "not_set"
+
+"""
+    get_level(::Logger)
+
+Returns the current logger level.
+"""
+get_level(logger::Logger) = logger.level
 
 """
     config(level::AbstractString; fmt::AbstractString, levels::Dict{AbstractString, Int}, colorized::Bool) -> Logger

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,7 +50,8 @@ cd(dirname(@__FILE__))
         car = get_logger("Foo.Car")
 
         for l in (foo, bar, baz, car)
-            @test !is_set(l)
+            @test is_set(l)
+            @test get_level(l) == "warn"
             @test length(get_handlers(l)) == 0
         end
 


### PR DESCRIPTION
1. Loading memento now runs `Memento.config("warn")` by default
2. Loggers are now initialized with level "warn" vs "not_set".

This required a couple test changes and we've added a `get_level` method to help with managing logger levels.