### PR TITLE
Drop 0.5 and reduce builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 env:
@@ -17,12 +16,10 @@ matrix:
     - julia: nightly
     - env: TEST_TYPE=bench
   exclude:
+    - if: branch != master
+      os: osx
     - julia: nightly
       env: TEST_TYPE=userimage
-    - julia: 0.5
-      env: TEST_TYPE=userimage
-    - julia: 0.5
-      env: TEST_TYPE=bench
     - os: osx
       env: TEST_TYPE=bench
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: julia
 os:
   - linux
-  - osx
 julia:
   - 0.6
   - nightly
@@ -15,13 +14,14 @@ matrix:
   allow_failures:
     - julia: nightly
     - env: TEST_TYPE=bench
-  exclude:
-    - if: branch != master
+  include:
+    - if: branch = master
+      julia: 0.6
       os: osx
+      env: TEST_TYPE=io
+  exclude:
     - julia: nightly
       env: TEST_TYPE=userimage
-    - os: osx
-      env: TEST_TYPE=bench
 
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
-julia 0.5
-Compat 0.17.0
+julia 0.6
 JSON 0.8
 Mocking 0.3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
     - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
     - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
     - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -3,7 +3,6 @@ __precompile__()
 module Memento
 
 using Mocking
-using Compat
 
 import Base: show, info, warn, error, log
 

--- a/src/formatters.jl
+++ b/src/formatters.jl
@@ -7,7 +7,7 @@ A `Formatter` must implement a `format(::Formatter, ::Record)` method
 which takes a `Record` and returns a `String` representation of the
 log `Record`.
 """
-@compat abstract type Formatter end
+abstract type Formatter end
 
 const DEFAULT_FMT_STRING = "[{level} | {name}]: {msg}"
 

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -9,7 +9,7 @@ method.
 NOTE: Handlers can useful if you need to special case logging behaviour
 based on the `Formatter`, `IO` and/or `Record` types.
 """
-@compat abstract type Handler{F<:Formatter, O<:IO} end
+abstract type Handler{F<:Formatter, O<:IO} end
 
 function Memento.Filter(h::Handler)
     function level_filter(rec::Record)

--- a/src/records.jl
+++ b/src/records.jl
@@ -51,7 +51,7 @@ message strings.
 NOTE: you should access `Attribute`s in a `Record` by using `getindex` (ie: record[:msg])
 as this will correctly extract the value from the `Attribute` container.
 """
-@compat abstract type Record end
+abstract type Record end
 
 Base.getindex(rec::Record, attr::Symbol) = get(getfield(rec, attr))
 


### PR DESCRIPTION
In an attempt to reduce our travis builds (particularly osx) we're dropping 0.5 support and limiting osx builds to master.