### PR TITLE
Updates to work on julia nightly again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ julia:
 env:
   - TEST_TYPE=parallel
   - TEST_TYPE=io
-  - TEST_TYPE=bench
+  # - TEST_TYPE=bench
   - TEST_TYPE=userimage
 matrix:
   fast_finish: true

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.6
+Compat 0.37.0
 JSON 0.8
 Mocking 0.3

--- a/docs/src/man/conclusion.md
+++ b/docs/src/man/conclusion.md
@@ -76,7 +76,7 @@ type EC2Record <: Record
         trace = Attribute(StackTrace, get_trace)
 
         EC2Record(
-            Attribute(DateTime, () -> round(time, Base.Dates.Second)),
+            Attribute(DateTime, () -> round(time, Dates.Second)),
             Attribute(args[:level]),
             Attribute(args[:levelnum]),
             Attribute(AbstractString, get_msg(args[:msg])),

--- a/docs/src/man/handlers.md
+++ b/docs/src/man/handlers.md
@@ -10,7 +10,7 @@ type MyHandler{F<:Formatter, O<:IO} <: Handler{F, O}
 end
 
 function emit{F<:Formatter, O<:IO}(handler::MyHandler{F, O}, rec::Record)
-    str = format(handler.fmt, rec)
+    str = Memento.format(handler.fmt, rec)
     println(handler.io, str)
     flush(handler.io)
 end
@@ -22,7 +22,7 @@ For example, the `Syslog` `IO` type needs an extra `level` argument to
 its `println` so we special case this like so:
 ```julia
 function emit{F<:Formatter, O<:Syslog}(handler::MyHandler{F, O}, rec::Record)
-    str = format(handler.fmt, rec)
+    str = Memento.format(handler.fmt, rec)
     println(handler.io, rec[:level], str)
     flush(handler.io)
 end

--- a/docs/src/man/records.md
+++ b/docs/src/man/records.md
@@ -27,7 +27,7 @@ type EC2Record <: Record
         trace = Attribute(StackTrace, get_trace)
 
         EC2Record(
-            Attribute(DateTime, () -> round(time, Base.Dates.Second)),
+            Attribute(DateTime, () -> round(time, Dates.Second)),
             Attribute(level),
             Attribute(-1),
             Attribute(AbstractString, get_msg(msg)),

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -11,7 +11,7 @@ import Base: show, info, warn, error, log
 export log, debug, info, notice, warn, error, critical, alert, emergency,
        is_set, is_root, get_level, set_level, add_level, set_record, add_filter,
        add_handler, remove_handler, remove_handlers, emit,
-       get_logger, get_handlers,
+       get_logger, get_handlers, format,
 
        Logger,
        Record, DefaultRecord,

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -3,13 +3,15 @@ __precompile__()
 module Memento
 
 using Mocking
+using Compat
+using Compat.Dates
 
 import Base: show, info, warn, error, log
 
 export log, debug, info, notice, warn, error, critical, alert, emergency,
        is_set, is_root, get_level, set_level, add_level, set_record, add_filter,
        add_handler, remove_handler, remove_handlers, emit,
-       get_logger, get_handlers, format,
+       get_logger, get_handlers,
 
        Logger,
        Record, DefaultRecord,

--- a/src/filters.jl
+++ b/src/filters.jl
@@ -7,7 +7,7 @@ a bool whether to skip logging it.
 # Fields
 `f::Function`: a function that should return a bool given a `Record`
 """
-immutable Filter
+struct Filter
     f::Function
 end
 

--- a/src/formatters.jl
+++ b/src/formatters.jl
@@ -23,7 +23,7 @@ Ex) "[{level} | {name}]: {msg}" will print message of the form
 [warn | root]: my warning message.
 ...
 """
-immutable DefaultFormatter <: Formatter
+struct DefaultFormatter <: Formatter
     fmt_str::AbstractString
     tokens::Vector{Pair{Symbol, Bool}}
 
@@ -91,7 +91,7 @@ end
 Uses the JSON pkg to format the `Record` into a valid
 JSON string.
 """
-type JsonFormatter <: Formatter
+struct JsonFormatter <: Formatter
     aliases::Nullable{Dict{Symbol, Symbol}}
 
     JsonFormatter() = new(Nullable())
@@ -106,7 +106,7 @@ and dicts respectively and call `JSON.json()` on the resulting dictionary.
 """
 function format(fmt::JsonFormatter, rec::Record)
     aliases = if isnull(fmt.aliases)
-        names = fieldnames(rec)
+        names = fieldnames(typeof(rec))
         Dict(zip(names, names))
     else
         get(fmt.aliases)

--- a/src/io.jl
+++ b/src/io.jl
@@ -15,7 +15,7 @@ log file.
 * `byteswritten::Int64`: keeps track of how many bytes have been written to the current file.
 * `max_sz::Int`: the maximum number of bytes written to a file before rolling over to another.
 """
-type FileRoller <: IO
+mutable struct FileRoller <: IO
     prefix::AbstractString
     folder::AbstractString
     filepath::AbstractString
@@ -114,7 +114,7 @@ FACILITIES = [
 * `tag::AbstractString`: a tag to use for all message (defaults to "julia")
 * `pid::Integer`: tags julia's pid to messages (defaults to -1 which doesn't include the pid)
 """
-type Syslog <: IO
+mutable struct Syslog <: IO
     facility::Symbol
     tag::AbstractString
     pid::Integer

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -17,7 +17,7 @@ loggers propagate their message to their parent loggers.
 * `propagate::Bool`: whether or not this logger should propagate its message to its parent
     (defaults to `true`).
 """
-type Logger
+mutable struct Logger
     name::AbstractString
     handlers::Dict{Any, Handler}
     level::AbstractString
@@ -52,8 +52,8 @@ type Logger
     end
 end
 
-function Logger{R<:Record}(name; level=DEFAULT_LOG_LEVEL, levels=_log_levels,
-                record::Type{R}=DefaultRecord, propagate=true)
+function Logger(name; level=DEFAULT_LOG_LEVEL, levels=_log_levels,
+                record::Type{R}=DefaultRecord, propagate=true) where {R<:Record}
     logger = Logger(
         name,
         Dict{Any, Handler}(),
@@ -218,7 +218,7 @@ Sets the record type for the logger.
 * `logger::Logger`: the logger to set.
 * `rec::Record`: A `Record` type to use for logging messages (ie: `DefaultRecord`).
 """
-set_record{R<:Record}(logger::Logger, rec::Type{R}) = logger.record = rec
+set_record(logger::Logger, rec::Type{R}) where {R<:Record} = logger.record = rec
 
 """
     remove_handler(logger::Logger, name)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,2 @@
-PkgBenchmark 0.0.1
-BenchmarkTools 0.0.7
+# PkgBenchmark 0.0.1
+# BenchmarkTools 0.0.7

--- a/test/formatters.jl
+++ b/test/formatters.jl
@@ -5,7 +5,7 @@ import Memento: Attribute
 
     @testset "DefaultFormatter" begin
         fmt = DefaultFormatter("{lookup}|{msg}|{stacktrace}")
-        result = format(fmt, rec)
+        result = Memento.format(fmt, rec)
         parts = split(result, "|")
         @test length(parts) == 3
         @test parts[2] == "blah"
@@ -19,7 +19,7 @@ import Memento: Attribute
 
     @testset "JsonFormatter" begin
         fmt = JsonFormatter()
-        result = format(fmt, rec)
+        result = Memento.format(fmt, rec)
         for key in [:date, :name, :level, :lookup, :stacktrace, :msg]
             @test contains(result, string(key))
         end
@@ -36,7 +36,7 @@ import Memento: Attribute
         )
 
         fmt2 = JsonFormatter(aliases)
-        result = format(fmt2, rec)
+        result = Memento.format(fmt2, rec)
 
         for key in [:location, :message, :timestamp, :process_id]
             @test contains(result, string(key))

--- a/test/handlers.jl
+++ b/test/handlers.jl
@@ -70,7 +70,7 @@
             log(logger, "fubar", "Something went very wrong")
 
             @test isfile(filename)
-            @test is_windows() ? true : success(`rm $filename`)
+            @test Sys.iswindows() ? true : success(`rm $filename`)
         end
 
         @testset "IO Construction" begin

--- a/test/io.jl
+++ b/test/io.jl
@@ -1,6 +1,3 @@
-using Base.Test
-#import Mocking: mend TODO
-
 @testset "IO" begin
     @testset "FileRoller" begin
         levels = Dict(
@@ -42,7 +39,7 @@ using Base.Test
 
     @testset "Syslog" begin
         @testset "Sample Usage" begin
-            if !is_windows()
+            if !Sys.iswindows()
                 levels = copy(Memento._log_levels)
                 levels["invalid"] = 100
                 handler = DefaultHandler(Syslog(:local0, "julia"), DefaultFormatter("{level}: {msg}"))
@@ -92,7 +89,7 @@ using Base.Test
                 @test_throws ErrorException Syslog(:local0, "julia")
             end
 
-            if is_windows()
+            if Sys.iswindows()
                 @test_throws ErrorException Syslog(:local0, "julia")
             end
         end

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -1,4 +1,4 @@
-immutable TestError <: Exception
+struct TestError <: Exception
     msg
 end
 


### PR DESCRIPTION
- Added Compat back in.
- Updated syntax now that we're off 0.5
- Updated parameterized function syntax
- Updated type definitions
- Fixed default io test behaviour to use `Mocking.enable(force=true)` by default
- Disabled benchmark tests for now cause installing HDF5 is slow and causing issues (and the benchmarks probably shouldn't run on travis anyways).