### PR TITLE
Support passing a function to set_level.

### DIFF
--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -268,6 +268,21 @@ function set_level(logger::Logger, level::AbstractString)
 end
 
 """
+    set_level(f::Function, logger::Logger, level::AbstractString)
+
+Temporarily change the level a logger will log at for the duration of the function `f`.
+"""
+function set_level(f::Function, logger::Logger, level::AbstractString)
+    original_level = logger.level
+    set_level(logger, level)
+    try
+        f()
+    finally
+        set_level(logger, original_level)
+    end
+end
+
+"""
     log(logger::Logger, args::Dict{Symbol, Any})
 
 Logs `logger.record(args)` to its handlers if it has the appropriate `args[:level]`

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -273,7 +273,7 @@ end
 Temporarily change the level a logger will log at for the duration of the function `f`.
 """
 function set_level(f::Function, logger::Logger, level::AbstractString)
-    original_level = logger.level
+    original_level = get_level(logger)
     set_level(logger, level)
     try
         f()

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -43,11 +43,11 @@ end
             set_level(logger, "info")
             @test logger.level == "info"
 
-            set_level(logger, "critical") do
-                @test logger.level == "critical"
+            set_level(logger, "error") do
+                @test get_level(logger) == "error"
                 warn("silenced message should not be displayed")
             end
-            @test logger.level == "info"
+            @test get_level(logger) == "info"
 
             set_record(logger, DefaultRecord)
 

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -43,6 +43,12 @@ end
             set_level(logger, "info")
             @test logger.level == "info"
 
+            set_level(logger, "critical") do
+                @test logger.level == "critical"
+                warn("silenced message should not be displayed")
+            end
+            @test logger.level == "info"
+
             set_record(logger, DefaultRecord)
 
             add_level(logger, "fubar", 50)


### PR DESCRIPTION
Sometimes it's nice to change the logging level for a small chunk of code (e.g., testing error conditions).