### PR TITLE
Memento.register

### DIFF
--- a/docs/src/man/intro.md
+++ b/docs/src/man/intro.md
@@ -83,3 +83,24 @@ There are five main components of Memento.jl that you can manipulate:
 5. IO
 
 The remainder of this manual will discuss how you can use these components to customize Memento to you particular application.
+
+## Using Memento from Julia Modules
+
+Some care needs to be taken when working with Memento from [precompiled modules](http://docs.julialang.org/en/latest/manual/modules/#module-initialization-and-precompilation).
+Specifically, it is important to note that if you want folks be able to configure your logger from outside the module you'll want to register the logger in your `__init__()` method.
+
+```julia
+__precompile__() # this module is safe to precompile
+module MyModule
+
+using Memento
+
+# Create our module level logger (this will get precompiled)
+const LOGGER = get_logger("MyModule")
+
+# Register the module level logger at runtime so that folks can access the logger via `get_logger("MyModule")`
+# NOTE: If this line is not included then the precompiled `MyModule.LOGGER` won't be registered at runtime.
+__init__() = Memento.register(LOGGER)
+
+end
+```

--- a/docs/src/man/intro.md
+++ b/docs/src/man/intro.md
@@ -86,7 +86,7 @@ The remainder of this manual will discuss how you can use these components to cu
 
 ## Using Memento from Julia Modules
 
-Some care needs to be taken when working with Memento from [precompiled modules](http://docs.julialang.org/en/latest/manual/modules/#module-initialization-and-precompilation).
+Some care needs to be taken when working with Memento from [precompiled modules](https://docs.julialang.org/en/stable/manual/modules/#module-initialization-and-precompilation).
 Specifically, it is important to note that if you want folks be able to configure your logger from outside the module you'll want to register the logger in your `__init__()` method.
 
 ```julia
@@ -96,9 +96,9 @@ module MyModule
 using Memento
 
 # Create our module level logger (this will get precompiled)
-const LOGGER = get_logger("MyModule")
+const LOGGER = get_logger(current_module())   # or `get_logger(@__MODULE__)` on 0.7
 
-# Register the module level logger at runtime so that folks can access the logger via `get_logger("MyModule")`
+# Register the module level logger at runtime so that folks can access the logger via `get_logger(MyModule)`
 # NOTE: If this line is not included then the precompiled `MyModule.LOGGER` won't be registered at runtime.
 __init__() = Memento.register(LOGGER)
 

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -102,6 +102,13 @@ Returns the current logger level.
 get_level(logger::Logger) = logger.level
 
 """
+    register(::Logger)
+
+Register an existing logger with Memento.
+"""
+register(logger::Logger) = global _loggers[logger.name] = logger
+
+"""
     config(level::AbstractString; fmt::AbstractString, levels::Dict{AbstractString, Int}, colorized::Bool) -> Logger
 
 Sets the `Memento._log_levels`, creates a default root logger with a `DefaultHandler`
@@ -119,9 +126,9 @@ that prints to STDOUT.
 """
 function config(level::AbstractString; fmt::AbstractString=DEFAULT_FMT_STRING, levels=_log_levels, colorized=true)
     global _log_levels = levels
-    _loggers["root"] = Logger("root"; level=level, levels=levels)
+    logger = Logger("root"; level=level, levels=levels)
     add_handler(
-        _loggers["root"],
+        logger,
         DefaultHandler(
             STDOUT,
             DefaultFormatter(fmt),
@@ -129,8 +136,9 @@ function config(level::AbstractString; fmt::AbstractString=DEFAULT_FMT_STRING, l
         ),
         "console"
     )
+    register(logger)
 
-    return _loggers["root"]
+    return logger
 end
 
 """
@@ -203,7 +211,7 @@ function get_logger(name="root")
 
     if !(haskey(_loggers, logger_name))
         parent = get_parent(logger_name)
-        _loggers[logger_name] = Logger(logger_name)
+        register(Logger(logger_name))
     end
 
     return _loggers[logger_name]


### PR DESCRIPTION
Added a Memento.register method for precompiled modules to use and included a section on using Memento in precompiled modules.