### PR TITLE
Remove extra `global` keyword.

### DIFF
--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -20,7 +20,7 @@ export log, debug, info, notice, warn, error, critical, alert, emergency,
 
 const DEFAULT_LOG_LEVEL = "warn"
 
-const global _log_levels = Dict{AbstractString, Int}(
+const _log_levels = Dict{AbstractString, Int}(
     "not_set" => 0,
     "debug" => 10,
     "info" => 20,
@@ -41,7 +41,7 @@ include("loggers.jl")
 
 # Initializing at compile-time will work as long as the loggers which are added do not
 # contain references to STDOUT.
-const global _loggers = Dict{AbstractString, Logger}(
+const _loggers = Dict{AbstractString, Logger}(
     "root" => Logger("root"),
 )
 

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -106,7 +106,7 @@ get_level(logger::Logger) = logger.level
 
 Register an existing logger with Memento.
 """
-register(logger::Logger) = global _loggers[logger.name] = logger
+register(logger::Logger) = _loggers[logger.name] = logger
 
 """
     config(level::AbstractString; fmt::AbstractString, levels::Dict{AbstractString, Int}, colorized::Bool) -> Logger
@@ -125,7 +125,7 @@ that prints to STDOUT.
 * `Logger`: the root logger.
 """
 function config(level::AbstractString; fmt::AbstractString=DEFAULT_FMT_STRING, levels=_log_levels, colorized=true)
-    global _log_levels = levels
+    _log_levels = levels
     logger = Logger("root"; level=level, levels=levels)
     add_handler(
         logger,
@@ -149,7 +149,7 @@ without any handlers.
 """
 function reset!()
     empty!(_loggers)
-    _loggers["root"] = Logger("root")
+    register(Logger("root"))
     nothing
 end
 


### PR DESCRIPTION
We're using `global` in a bunch of places we don't really need.