### PR TITLE
Renamed a significant part of the API to be more julian

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ julia> Pkg.add("Memento")
 
 ## Quick Start
 
-[![asciicast](https://asciinema.org/a/152909.png)](https://asciinema.org/a/152909)
+[![asciicast](https://asciinema.org/a/153324.png)](https://asciinema.org/a/153324)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ julia> Pkg.add("Memento")
 
 ## Quick Start
 
-[![asciicast](https://asciinema.org/a/152535.png)](https://asciinema.org/a/152535)
+[![asciicast](https://asciinema.org/a/152909.png)](https://asciinema.org/a/152909)
 
 ## Documentation
 

--- a/docs/quickstart.jl
+++ b/docs/quickstart.jl
@@ -10,6 +10,7 @@ error(logger, "Something that should throw an error.")
 critical(logger, "The world is exploding")
 child_logger = getlogger("Foo.bar")
 setlevel!(child_logger, "warn")
-child_logger += DefaultHandler(tempname(), DefaultFormatter("[{date} | {level} | {name}]: {msg}"));
+push!(child_logger, DefaultHandler(tempname(), DefaultFormatter("[{date} | {level} | {name}]: {msg}")));
 debug(child_logger, "Something that should only be printed to STDOUT on the root_logger.")
 warn(child_logger, "Warning to STDOUT and the log file.")
+exit()

--- a/docs/quickstart.jl
+++ b/docs/quickstart.jl
@@ -8,8 +8,8 @@ notice(logger, "This is probably pretty important.")
 warn(logger, ErrorException("A caught exception that we want to log as a warning."))
 error(logger, "Something that should throw an error.")
 critical(logger, "The world is exploding")
-child_logger = get_logger("Foo.bar")
-set_level(child_logger, "warn")
-add_handler(child_logger, DefaultHandler(tempname(), DefaultFormatter("[{date} | {level} | {name}]: {msg}")));
+child_logger = getlogger("Foo.bar")
+setlevel!(child_logger, "warn")
+child_logger += DefaultHandler(tempname(), DefaultFormatter("[{date} | {level} | {name}]: {msg}"));
 debug(child_logger, "Something that should only be printed to STDOUT on the root_logger.")
 warn(child_logger, "Warning to STDOUT and the log file.")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -50,13 +50,13 @@ ERROR: Something that should throw an error.
 Now maybe you want to have a different logger for each module/submodule.
 This allows you to have custom logging behaviour and handlers for different modules and provides easier to parse logging output.
 ```julia
-julia> child_logger = get_logger("Foo.bar")
+julia> child_logger = getlogger("Foo.bar")
 Logger(Foo.bar)
 
-julia> set_level(child_logger, "warn")
+julia> setlevel!(child_logger, "warn")
 "warn"
 
-julia> add_handler(child_logger, DefaultHandler(tempname(), DefaultFormatter("[{date} | {level} | {name}]: {msg}")))
+julia> child_logger += DefaultHandler(tempname(), DefaultFormatter("[{date} | {level} | {name}]: {msg}"))
 
 Memento.DefaultHandler{Memento.DefaultFormatter,IOStream}(Memento.DefaultFormatter("[{date} | {level} | {name}]: {msg}"),IOStream(<file /var/folders/_6/25myjdtx2fxgjvznn19rp22m0000gn/T/julia8lonyA>),Dict{Symbol,Any}(Pair{Symbol,Any}(:is_colorized,false)))
 
@@ -66,4 +66,4 @@ julia> debug(child_logger, "Something that should only be printed to STDOUT on t
 julia> warn(child_logger, "Warning to STDOUT and the log file.")
 [warn | Foo.bar]: Warning to STDOUT and the log file.
 ```
-NOTE: We used `get_logger("Foo.bar")`, but you can also do `get_logger(current_module())` which allows us to avoid hard coding in logger names.
+NOTE: We used `getlogger("Foo.bar")`, but you can also do `getlogger(current_module())` which allows us to avoid hard coding in logger names.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -56,7 +56,7 @@ Logger(Foo.bar)
 julia> setlevel!(child_logger, "warn")
 "warn"
 
-julia> child_logger += DefaultHandler(tempname(), DefaultFormatter("[{date} | {level} | {name}]: {msg}"))
+julia> push!(child_logger, DefaultHandler(tempname(), DefaultFormatter("[{date} | {level} | {name}]: {msg}")))
 
 Memento.DefaultHandler{Memento.DefaultFormatter,IOStream}(Memento.DefaultFormatter("[{date} | {level} | {name}]: {msg}"),IOStream(<file /var/folders/_6/25myjdtx2fxgjvznn19rp22m0000gn/T/julia8lonyA>),Dict{Symbol,Any}(Pair{Symbol,Any}(:is_colorized,false)))
 

--- a/docs/src/man/conclusion.md
+++ b/docs/src/man/conclusion.md
@@ -136,14 +136,17 @@ end
 
 # Now we can tie this all together, but adding a new DefaultHandler
 # with the CSVFormatter and REST IO type.
-logger += DefaultHandler(
-    REST(
-        "memento.mylogrestservice.com", "myapp",
-        "qM033cSYWTuu8VpXFSZm9QMm9ZESOU2A"
-    ),
-    CSVFormatter(
-        ',',
-        [:date, :name, :level, :msg, :iam_user, :public_ip, :instance_id]
+push!(
+    logger,
+    DefaultHandler(
+        REST(
+            "memento.mylogrestservice.com", "myapp",
+            "qM033cSYWTuu8VpXFSZm9QMm9ZESOU2A"
+        ),
+        CSVFormatter(
+            ',',
+            [:date, :name, :level, :msg, :iam_user, :public_ip, :instance_id]
+        )
     )
 )
 

--- a/docs/src/man/conclusion.md
+++ b/docs/src/man/conclusion.md
@@ -14,7 +14,7 @@ using Memento
 
 function run(f::Function, args...; kwargs...)
     ret = nothing
-    logger = get_logger(current_module())
+    logger = getlogger(current_module())
     info(logger, "Got logger $logger")
 
     notice(logger, "Running function...")
@@ -136,7 +136,7 @@ end
 
 # Now we can tie this all together, but adding a new DefaultHandler
 # with the CSVFormatter and REST IO type.
-add_handler(logger, DefaultHandler(
+logger += DefaultHandler(
     REST(
         "memento.mylogrestservice.com", "myapp",
         "qM033cSYWTuu8VpXFSZm9QMm9ZESOU2A"
@@ -145,10 +145,10 @@ add_handler(logger, DefaultHandler(
         ',',
         [:date, :name, :level, :msg, :iam_user, :public_ip, :instance_id]
     )
-))
+)
 
 # Don't forget to update the root logger `Record` type.
-set_record(logger, EC2Record)
+setrecord!(logger, EC2Record)
 
 Wrapper.run(exp, 10)
 # Should log some things.

--- a/docs/src/man/intro.md
+++ b/docs/src/man/intro.md
@@ -14,7 +14,7 @@ Will only log message at or above the "warn" level.
 
 We can also set the logging level for specific loggers or collections of loggers if we explicitly set the level on an existing logger.
 ```julia
-julia>set_level(get_logger("Main"), "info")
+julia>setlevel!(getlogger("Main"), "info")
 ```
 Will only set the logging level to "info" for the "Main" logger and any future children of the "Main" logger.
 

--- a/docs/src/man/loggers.md
+++ b/docs/src/man/loggers.md
@@ -1,32 +1,28 @@
 # Loggers
 
 A `Logger` is the primary component you use to send formatted log messages to various IO outputs. This type holds information needed to manage the process of creating and storing logs. There is a default "root" logger stored in global `_loggers` inside the `Memento` module. Since Memento implements hierarchical logging you should define child loggers that can be configured independently and better describe the individual components within your code.
-To create a new logger for you code it is recommended to do `get_logger(current_module())`.
+To create a new logger for you code it is recommended to do `getlogger(current_module())`.
 
 ```julia
-julia> logger = get_logger(current_module())
+julia> logger = getlogger(current_module())
 ```
 
 Log messages are brought to different output streams by `Handlers`. From here you can add and remove handlers. To add a handler that writes to rotating log files, simply:
 
 ```julia
-julia> add_handler(logger, DefaultHandler("mylogfile.log"), "file-logging")
+julia> logger += DefaultHandler("mylogfile.log")
 ```
 
-Now there is a handler named "file-logging", and it will write all of your logs to `mylogfile.log`. Your logs will still show up in the console, however, because -by default- there is a handler named "console" already hard at work. Remove it by calling:
-
-```julia
-julia> remove_handler(logger, "console")
-```
+Now there is a handler named "file-logging", and it will write all of your logs to `mylogfile.log`. Your logs will still show up in the console, however, because -by default- there is a handler named "console" already hard at work.
 
 The operations presented here will only apply to the current logger, leaving existing loggers (e.g., `Logger(root)`) unaffected. However, any child loggers of `Logger(Main)` (e.g., `Logger(Main.Foo)` will have both the "console" and "file-logging" handlers available to it.
 
 We can also set the level and `Record` type for our logger.
 ```julia
-julia> set_level(logger, "warn")
+julia> setlevel!(logger, "warn")
 ```
 Now we won't log any messages with this logger unless they are at least warning messages.
 ```julia
-julia> set_record(logger, MyRecord)
+julia> setrecord!(logger, MyRecord)
 ```
 Now our logger will call create `MyRecord`s instead of `DefaultRecord`s

--- a/docs/src/man/loggers.md
+++ b/docs/src/man/loggers.md
@@ -10,7 +10,7 @@ julia> logger = getlogger(current_module())
 Log messages are brought to different output streams by `Handlers`. From here you can add and remove handlers. To add a handler that writes to rotating log files, simply:
 
 ```julia
-julia> logger += DefaultHandler("mylogfile.log")
+julia> push!(logger, DefaultHandler("mylogfile.log"))
 ```
 
 Now there is a handler named "file-logging", and it will write all of your logs to `mylogfile.log`. Your logs will still show up in the console, however, because -by default- there is a handler named "console" already hard at work.

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -10,16 +10,29 @@ import JSON
 
 import Base: show, info, warn, error, log
 
-export log, debug, info, notice, warn, error, critical, alert, emergency,
-       is_set, is_root, get_level, set_level, add_level, set_record, add_filter,
-       add_handler, remove_handler, remove_handlers, emit,
-       get_logger, get_handlers, format,
+export debug, notice, error, critical, alert, emergency,
+       isset, isroot, ispropagating, setpropagating!,
+       getlevel, setlevel!, addlevel!, setrecord!,
+       getlogger, gethandlers, getfilters, format, emit,
 
-       Logger,
-       Record, DefaultRecord,
-       Formatter, DefaultFormatter, DictFormatter,
-       Handler, DefaultHandler,
-       FileRoller, Syslog
+       Logger,Record, DefaultRecord, Formatter, Handler,
+       DefaultFormatter, DictFormatter, DefaultHandler, FileRoller,
+
+       # Deprecated
+       Syslog,
+       JsonFormatter,
+       is_set,
+       is_root,
+       get_level,
+       set_level,
+       add_level,
+       set_record,
+       filters,
+       add_filter,
+       add_handler,
+       remove_handler,
+       get_logger,
+       get_handlers
 
 const DEFAULT_LOG_LEVEL = "warn"
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -19,3 +19,54 @@ end
 @deprecate JsonFormatter(aliases=Nullable()) DictFormatter(aliases, JSON.json)
 
 # END Memento 0.4 deprecations
+
+# BEGIN Memento 0.5 deprecations
+
+# Logger deprecations
+@deprecate is_root(logger::Logger) isroot(logger::Logger)
+@deprecate is_set(logger::Logger) isset(logger::Logger)
+@deprecate get_level(logger::Logger) getlevel(logger::Logger)
+@deprecate get_parent(name) getparent(name)
+@deprecate get_logger() getlogger()
+@deprecate get_logger(name) getlogger(name)
+@deprecate set_record(logger::Logger, rec) setrecord!(logger, rec)
+@deprecate filters(logger::Logger) getfilters(logger::Logger)
+@deprecate add_filter(logger::Logger, filter::Memento.Filter) push!(logger, filter)
+@deprecate get_handlers(logger::Logger) gethandlers(logger::Logger)
+@deprecate add_level(logger::Logger, level, val) addlevel!(logger, level, val)
+@deprecate set_level(logger::Logger, level) setlevel!(logger, level)
+@deprecate set_level(f::Function, logger::Logger, level) setlevel!(f, logger, level)
+
+"""
+    add_handler(logger::Logger, handler::Handler, name)
+
+Adds a new handler to `logger.handlers`. If a name is not provided a
+random one will be generated.
+
+# Arguments
+* `logger::Logger`: the logger to use.
+* `handler::Handler`: the handler to add.
+* `name::AbstractString`: a name to identify the handler.
+"""
+function add_handler(logger::Logger, handler::Handler, name=string(Base.Random.uuid4()))
+    Base.depwarn("`add_handler(logger, handler[, name])` is being deprecated in favour of `push!(logger, handler)`", :add_handler)
+    handler.levels.x = logger.levels
+    logger.handlers[name] = handler
+end
+
+"""
+    remove_handler(logger::Logger, name)
+
+Removes the `Handler` with the provided name from the logger.handlers.
+"""
+function remove_handler(logger::Logger, name)
+    Base.depwarn("`remove_handler(logger, name)` is being deprecated.", :remove_handler)
+    delete!(logger.handlers, name)
+end
+
+# Handler deprecations
+@deprecate filters(handler::DefaultHandler) getfilters(handler)
+@deprecate add_filter(handler::DefaultHandler, filter::Memento.Filter) push!(handler, filter)
+@deprecate set_level(handler::DefaultHandler, level::AbstractString) setlevel!(handler, level)
+
+# END Memento 0.5 deprecations

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -68,7 +68,7 @@ Creates a DefaultHandler with the specified IO type.
 function DefaultHandler(io::O, fmt::F=DefaultFormatter(), opts=Dict{Symbol, Any}()) where {F<:Formatter, O<:IO}
     setup_opts(opts)
     handler = DefaultHandler(fmt, io, opts, Memento.Filter[], Ref(_log_levels), "not_set")
-    handler += Memento.Filter(handler)
+    push!(handler, Memento.Filter(handler))
     return handler
 end
 
@@ -86,7 +86,7 @@ function DefaultHandler(filename::AbstractString, fmt::F=DefaultFormatter(), opt
     file = open(filename, "a")
     setup_opts(opts)
     handler = DefaultHandler(fmt, file, opts, Memento.Filter[], Ref(_log_levels), "not_set")
-    handler += Memento.Filter(handler)
+    push!(handler, Memento.Filter(handler))
     finalizer(handler, h -> close(h.io))
     handler
 end

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -11,6 +11,11 @@ based on the `Formatter`, `IO` and/or `Record` types.
 """
 abstract type Handler{F<:Formatter, O<:IO} end
 
+function Base.:+(handler::Handler, filter::Memento.Filter)
+    push!(handler, filter)
+    return handler
+end
+
 """
     log(handler::Handler, rec::Record)
 
@@ -18,7 +23,7 @@ Checks the `Handler` filters and if they all pass then
 `emit` the record.
 """
 function log(handler::Handler, rec::Record)
-    if all(f -> f(rec), filters(handler))
+    if all(f -> f(rec), getfilters(handler))
         emit(handler, rec)
     end
 end
@@ -63,7 +68,7 @@ Creates a DefaultHandler with the specified IO type.
 function DefaultHandler(io::O, fmt::F=DefaultFormatter(), opts=Dict{Symbol, Any}()) where {F<:Formatter, O<:IO}
     setup_opts(opts)
     handler = DefaultHandler(fmt, io, opts, Memento.Filter[], Ref(_log_levels), "not_set")
-    push!(handler.filters, Memento.Filter(handler))
+    handler += Memento.Filter(handler)
     return handler
 end
 
@@ -81,7 +86,7 @@ function DefaultHandler(filename::AbstractString, fmt::F=DefaultFormatter(), opt
     file = open(filename, "a")
     setup_opts(opts)
     handler = DefaultHandler(fmt, file, opts, Memento.Filter[], Ref(_log_levels), "not_set")
-    add_filter(handler, Memento.Filter(handler))
+    handler += Memento.Filter(handler)
     finalizer(handler, h -> close(h.io))
     handler
 end
@@ -123,27 +128,27 @@ function Memento.Filter(h::DefaultHandler)
 end
 
 """
-    filters(handler::DefaultHandler) -> Array{Filter}
+    getfilters(handler::DefaultHandler) -> Array{Filter}
 
 Returns the filters for the handler.
 """
-filters(handler::DefaultHandler) = handler.filters
+getfilters(handler::DefaultHandler) = handler.filters
 
 """
-    add_filter(handler::DefaultHandler, filter::Memento.Filter)
+    push!(handler::DefaultHandler, filter::Memento.Filter)
 
 Adds an new `Filter` to the handler.
 """
-function add_filter(handler::DefaultHandler, filter::Memento.Filter)
+function Base.push!(handler::DefaultHandler, filter::Memento.Filter)
     push!(handler.filters, filter)
 end
 
 """
-    set_level(handler::DefaultHandler, level::AbstractString)
+    setlevel!(handler::DefaultHandler, level::AbstractString)
 
 Sets the minimum level required to `emit` the record from the handler.
 """
-function set_level(handler::DefaultHandler, level::AbstractString)
+function setlevel!(handler::DefaultHandler, level::AbstractString)
     handler.levels.x[level]     # Throw a key error if the levels isn't in levels
     handler.level = level
 end

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -45,8 +45,8 @@ mutable struct Logger
             handler.levels = Ref(logger.levels)
         end
 
-        add_filter(logger, Memento.Filter(rec -> is_set(logger)))
-        add_filter(logger, Memento.Filter(logger))
+        logger += Memento.Filter(rec -> isset(logger))
+        logger += Memento.Filter(logger)
 
         return logger
     end
@@ -73,6 +73,13 @@ function Memento.Filter(l::Logger)
     Memento.Filter(level_filter)
 end
 
+# We overload `+`, so that folks can push handlers and filters into the logger with
+# `logger += handler`
+function Base.:+(logger::Logger, x::Union{Handler, Memento.Filter})
+    push!(logger, x)
+    return logger
+end
+
 """
     Base.show(::IO, ::Logger)
 
@@ -81,25 +88,39 @@ Just prints `Logger(logger.name)`
 Base.show(io::IO, logger::Logger) = print(io, "Logger($(logger.name))")
 
 """
-    is_root(::Logger)
+    isroot(::Logger)
 
 Returns true if `logger.name`is "root" or ""
 """
-is_root(logger::Logger) = logger.name == "root" || logger.name == ""
+isroot(logger::Logger) = logger.name == "root" || logger.name == ""
 
 """
-    is_set(::Logger)
+    isset(::Logger)
 
 Returns true or false as to whether the logger is set. (ie: logger.level != "not_set")
 """
-is_set(logger::Logger) = logger.level != "not_set"
+isset(logger::Logger) = logger.level != "not_set"
 
 """
-    get_level(::Logger)
+    ispropagating(::Logger)
+
+Returns true or false as to whether the logger is propagating.
+"""
+ispropagating(logger::Logger) = logger.propagate
+
+"""
+    setpropagating!(::Logger, [::Bool])
+
+Sets the logger to be propagating or not (Defaults to true).
+"""
+setpropagating!(logger::Logger, val::Bool=true) = logger.propagate = val
+
+"""
+    getlevel(::Logger)
 
 Returns the current logger level.
 """
-get_level(logger::Logger) = logger.level
+getlevel(logger::Logger) = logger.level
 
 """
     register(::Logger)
@@ -127,15 +148,9 @@ that prints to STDOUT.
 function config(level::AbstractString; fmt::AbstractString=DEFAULT_FMT_STRING, levels=_log_levels, colorized=true)
     _log_levels = levels
     logger = Logger("root"; level=level, levels=levels)
-    add_handler(
-        logger,
-        DefaultHandler(
-            STDOUT,
-            DefaultFormatter(fmt),
-            Dict{Symbol, Any}(:is_colorized => colorized)
-        ),
-        "console"
-    )
+    handler = DefaultHandler(STDOUT, DefaultFormatter(fmt), Dict{Symbol, Any}(:is_colorized => colorized))
+
+    logger.handlers["console"] = handler
     register(logger)
 
     return logger
@@ -154,7 +169,7 @@ function reset!()
 end
 
 """
-    get_parent(name::AbstractString) -> Logger
+    getparent(name::AbstractString) -> Logger
 
 Takes a string representing the name of a logger and returns
 its parent. If the logger name has no parent then the root logger is returned.
@@ -167,20 +182,20 @@ Parent loggers are extracted assuming a naming convention of "foo.bar.baz", wher
 # Returns
 * `Logger`: the parent logger.
 """
-function get_parent(name)
+function getparent(name)
     tokenized = split(name, '.')
 
     if length(tokenized) == 1
-        return get_logger("root")
+        return getlogger("root")
     elseif length(tokenized) == 2
-        return get_logger(tokenized[1])
+        return getlogger(tokenized[1])
     else
-        return get_logger(join(tokenized[1:end-1], '.'))
+        return getlogger(join(tokenized[1:end-1], '.'))
     end
 end
 
 """
-    get_logger(name::Module) -> Logger
+    getlogger(name::Module) -> Logger
 
 Converts the `Module` to a `String` and calls `get_logger(name::String)`.
 
@@ -192,10 +207,10 @@ Converts the `Module` to a `String` and calls `get_logger(name::String)`.
 
 Returns the logger.
 """
-get_logger(name::Module) = get_logger("$name")
+getlogger(name::Module) = getlogger("$name")
 
 """
-    get_logger(name::AbstractString) -> Logger
+    getlogger(name::AbstractString) -> Logger
 
 If the logger or its parents do not exist then they are initialized
 with no handlers and not set.
@@ -206,11 +221,11 @@ with no handlers and not set.
 # Returns
 * `Logger`: the logger.
 """
-function get_logger(name="root")
+function getlogger(name="root")
     logger_name = name == "" ? "root" : name
 
     if !(haskey(_loggers, logger_name))
-        parent = get_parent(logger_name)
+        parent = getparent(logger_name)
         register(Logger(logger_name))
     end
 
@@ -218,7 +233,7 @@ function get_logger(name="root")
 end
 
 """
-    set_record{R<:Record}(logger::Logger, rec::Type{R})
+    setrecord!{R<:Record}(logger::Logger, rec::Type{R})
 
 Sets the record type for the logger.
 
@@ -226,83 +241,68 @@ Sets the record type for the logger.
 * `logger::Logger`: the logger to set.
 * `rec::Record`: A `Record` type to use for logging messages (ie: `DefaultRecord`).
 """
-set_record(logger::Logger, rec::Type{R}) where {R<:Record} = logger.record = rec
+setrecord!(logger::Logger, rec::Type{R}) where {R<:Record} = logger.record = rec
 
 """
-    filters(logger::Logger) -> Array{Filter}
+    getfilters(logger::Logger) -> Array{Filter}
 
 Returns the filters for the logger.
 """
-filters(logger::Logger) = logger.filters
+getfilters(logger::Logger) = logger.filters
 
 """
-    add_filter(logger::Logger, filter::Memento.Filter)
+    push!(logger::Logger, filter::Memento.Filter)
 
 Adds an new `Filter` to the logger.
 """
-function add_filter(logger::Logger, filter::Memento.Filter)
-    push!(logger.filters, filter)
-end
+Base.push!(logger::Logger, filter::Memento.Filter) = push!(logger.filters, filter)
 
 """
-    remove_handler(logger::Logger, name)
-
-Removes the `Handler` with the provided name from the logger.handlers.
-"""
-remove_handler(logger::Logger, name) = delete!(logger.handlers, name)
-
-"""
-    get_handlers(logger::Logger)
+    gethandlers(logger::Logger)
 
 Returns logger.handlers
 """
-get_handlers(logger::Logger) = logger.handlers
+gethandlers(logger::Logger) = logger.handlers
 
 """
-    add_handler(logger::Logger, handler::Handler, name)
+    push!(logger::Logger, handler::Handler)
 
-Adds a new handler to `logger.handlers`. If a name is not provided a
-random one will be generated.
-
-# Arguments
-* `logger::Logger`: the logger to use.
-* `handler::Handler`: the handler to add.
-* `name::AbstractString`: a name to identify the handler.
+Adds a new `Handler` to the logger.
 """
-function add_handler(logger::Logger, handler::Handler, name=string(Base.Random.uuid4()))
+function Base.push!(logger::Logger, handler::Handler)
     handler.levels.x = logger.levels
-    logger.handlers[name] = handler
+    logger.handlers[string(Base.Random.uuid4())] = handler
 end
 
 """
-    add_level(logger::Logger, level::AbstractString, val::Int)
+    addlevel!(logger::Logger, level::AbstractString, val::Int)
 
 Adds a new `level::String` and `priority::Int` to the `logger.levels`
 """
-add_level(logger::Logger, level::AbstractString, val::Int) = logger.levels[level] = val
+addlevel!(logger::Logger, level::AbstractString, val::Int) = logger.levels[level] = val
 
 """
-    set_level(logger::Logger, level::AbstractString)
+    setlevel!(logger::Logger, level::AbstractString)
 
 Changes what level this logger should log at.
 """
-function set_level(logger::Logger, level::AbstractString)
+function setlevel!(logger::Logger, level::AbstractString)
     logger.levels[level]    # Throw a key error if the levels isn't in levels
     logger.level = level
 end
 
 """
-    set_level(f::Function, logger::Logger, level::AbstractString)
+    setlevel!(f::Function, logger::Logger, level::AbstractString)
 
 Temporarily change the level a logger will log at for the duration of the function `f`.
 """
-function set_level(f::Function, logger::Logger, level::AbstractString)
-    original_level = get_level(logger)
-    set_level(logger, level)
+function setlevel!(f::Function, logger::Logger, level::AbstractString)
+    original_level = getlevel(logger)
+    setlevel!(logger, level)
     try
         f()
     finally
-        set_level(logger, original_level)
+        setlevel!(logger, original_level)
     end
 end
 
@@ -323,14 +323,14 @@ method with a `@sync` in order to synchronize all handler tasks.
 """
 function log(logger::Logger, rec::Record)
     # If none of the `Filter`s return false we're good to log our record.
-    if all(f -> f(rec), filters(logger))
+    if all(f -> f(rec), getfilters(logger))
         for (name, handler) in logger.handlers
             @async log(handler, rec)
         end
     end
 
-    if !is_root(logger) && logger.propagate
-        log(get_parent(logger.name), rec)
+    if !isroot(logger) && logger.propagate
+        log(getparent(logger.name), rec)
     end
 end
 

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -45,8 +45,8 @@ mutable struct Logger
             handler.levels = Ref(logger.levels)
         end
 
-        logger += Memento.Filter(rec -> isset(logger))
-        logger += Memento.Filter(logger)
+        push!(logger, Memento.Filter(rec -> isset(logger)))
+        push!(logger, Memento.Filter(logger))
 
         return logger
     end
@@ -71,13 +71,6 @@ function Memento.Filter(l::Logger)
     end
 
     Memento.Filter(level_filter)
-end
-
-# We overload `+`, so that folks can push handlers and filters into the logger with
-# `logger += handler`
-function Base.:+(logger::Logger, x::Union{Handler, Memento.Filter})
-    push!(logger, x)
-    return logger
 end
 
 """

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -2,3 +2,4 @@
 # BenchmarkTools 0.0.7
 Syslogs 0.0.1
 JSON 0.16.1
+Suppressor 0.0.5

--- a/test/concurrency.jl
+++ b/test/concurrency.jl
@@ -8,14 +8,13 @@
         io = IOBuffer()
 
         try
-            set_level(get_logger(), "info")
-            add_handler(
-                get_logger(),
-                DefaultHandler(io, DefaultFormatter("{name} - {level}: {msg}")),
-                "io"
+            setlevel!(getlogger(), "info")
+            push!(
+                getlogger(),
+                DefaultHandler(io, DefaultFormatter("{name} - {level}: {msg}"))
             )
 
-            asyncmap(x -> warn(get_logger(), "message"), 1:10)
+            asyncmap(x -> warn(getlogger(), "message"), 1:10)
             all_msgs = split(String(take!(io)), '\n')
 
             @test !isempty(all_msgs)
@@ -33,14 +32,13 @@
             @eval @everywhere parallel_test_filename = $(tempname())
 
             @everywhere using Memento
-            @everywhere set_level(get_logger(), "info")
-            @everywhere add_handler(
-                get_logger(),
-                DefaultHandler(parallel_test_filename, DefaultFormatter("{name} - {level}: {msg}")),
-                "io"
+            @everywhere setlevel!(getlogger(), "info")
+            @everywhere push!(
+                getlogger(),
+                DefaultHandler(parallel_test_filename, DefaultFormatter("{name} - {level}: {msg}"))
             )
 
-            pmap(x -> warn(get_logger(), "message"), 1:10)
+            pmap(x -> warn(getlogger(), "message"), 1:10)
 
             open(parallel_test_filename) do f
                 all_msgs = readlines(f)

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -63,82 +63,84 @@
 
             try
                 # Can't properly test subsequent deprecations because of
-                # https://github.com/JuliaLang/julia/issues/22043
+                # https://github.com/JuliaLang/julia/issues/22043, but should be fixed by
+                # https://github.com/JuliaLang/julia/pull/24490
+                if VERSION < v"0.7.0-DEV.2988"
+                    @suppress add_handler(getlogger(), handler, "testhandler")
+                    @suppress remove_handler(getlogger(), "testhandler")
+                else
+                    logger = @test_warn(
+                        "get_logger(name) is deprecated, use getlogger(name) instead.",
+                        get_logger("Logger.example")
+                    )
 
-                # logger = @test_warn(
-                #     "get_logger(name) is deprecated, use getlogger(name) instead.",
-                #     get_logger("Logger.example")
-                # )
+                    @test_warn(
+                        "is_root(logger::Logger) is deprecated, use isroot(logger::Logger) instead.",
+                        is_root(logger)
+                    )
 
-                # @test_warn(
-                #     "is_root(logger::Logger) is deprecated, use isroot(logger::Logger) instead.",
-                #     is_root(logger)
-                # )
+                    @test_warn(
+                        "is_set(logger::Logger) is deprecated, use isset(logger::Logger) instead.",
+                        is_set(logger)
+                    )
 
-                # @test_warn(
-                #     "is_set(logger::Logger) is deprecated, use isset(logger::Logger) instead.",
-                #     is_set(logger)
-                # )
+                    @test_warn(
+                        "get_level(logger::Logger) is deprecated, use getlevel(logger::Logger) instead.",
+                        get_level(logger)
+                    )
 
-                # @test_warn(
-                #     "get_level(logger::Logger) is deprecated, use getlevel(logger::Logger) instead.",
-                #     get_level(logger)
-                # )
+                    @test_warn(
+                        "get_parent(logger::Logger) is deprecated, use getparent(logger::Logger) instead.",
+                        getparent(logger)
+                    )
 
-                # @test_warn(
-                #     "get_parent(logger::Logger) is deprecated, use getparent(logger::Logger) instead.",
-                #     getparent(logger)
-                # )
+                    @test_warn(
+                        "set_record(logger::Logger, rec) is deprecated, use setrecord!(logger::Logger, rec) instead.",
+                        setrecord!(logger, DefaultRecord)
+                    )
 
-                # @test_warn(
-                #     "set_record(logger::Logger, rec) is deprecated, use setrecord!(logger::Logger, rec) instead.",
-                #     setrecord!(logger, DefaultRecord)
-                # )
+                    @test_warn(
+                        "filters(logger::Logger) is deprecated, use getfilters(logger::Logger) instead.",
+                        filters(logger)
+                    )
 
-                # @test_warn(
-                #     "filters(logger::Logger) is deprecated, use getfilters(logger::Logger) instead.",
-                #     filters(logger)
-                # )
+                    @test_warn(
+                        "add_filter(logger::Logger, filter::Memento.Filter) is deprecated, use push!(logger::Logger, filter::Memento.Filter) instead.",
+                        add_filter(logger, Memento.Filter(logger))
+                    )
 
-                # @test_warn(
-                #     "add_filter(logger::Logger, filter::Memento.Filter) is deprecated, use push!(logger::Logger, filter::Memento.Filter) instead.",
-                #     add_filter(logger, Memento.Filter(logger))
-                # )
+                    @test_warn(
+                        "get_handlers(logger::Logger) is deprecated, use gethandlers(logger::Logger) instead.",
+                        get_handlers(logger)
+                    )
 
-                # @test_warn(
-                #     "get_handlers(logger::Logger) is deprecated, use gethandlers(logger::Logger) instead.",
-                #     get_handlers(logger)
-                # )
+                    @test_warn(
+                        "add_level(logger::Logger, level, val) is deprecated, use addlevel!(logger::Logger, level, val) instead.",
+                        add_level(logger, "testlevel", 89)
+                    )
 
-                # @test_warn(
-                #     "add_level(logger::Logger, level, val) is deprecated, use addlevel!(logger::Logger, level, val) instead.",
-                #     add_level(logger, "testlevel", 89)
-                # )
+                    @test_warn(
+                        "set_level(logger::Logger, level) is deprecated, use setlevel!(logger::Logger, level) instead.",
+                        set_level(logger, "info")
+                    )
 
-                # @test_warn(
-                #     "set_level(logger::Logger, level) is deprecated, use setlevel!(logger::Logger, level) instead.",
-                #     set_level(logger, "info")
-                # )
+                    @test_warn(
+                        "set_level(f::Function, logger::Logger, level) is deprecated, use setlevel!(f::Function, logger::Logger, level) instead.",
+                        set_level(logger, "error") do
+                            warn(logger, "silenced message should not be displayed")
+                        end
+                    )
 
-                # @test_warn(
-                #     "set_level(f::Function, logger::Logger, level) is deprecated, use setlevel!(f::Function, logger::Logger, level) instead.",
-                #     set_level(logger, "error") do
-                #         warn(logger, "silenced message should not be displayed")
-                #     end
-                # )
+                    @test_warn(
+                        "`add_handler(logger, handler[, name])` is being deprecated in favour of `push!(logger, handler)`",
+                        add_handler(getlogger(), handler, "testhandler")
+                    )
 
-                # @test_warn(
-                #     "`add_handler(logger, handler[, name])` is being deprecated in favour of `push!(logger, handler)`",
-                #     add_handler(getlogger(), handler, "testhandler")
-                # )
-                @suppress add_handler(getlogger(), handler, "testhandler")
-
-                # @test_warn(
-                #     "`remove_handler(logger, name)` is being deprecated.",
-                #     remove_handler(getlogger(), "testhandler")
-                # )
-
-                @suppress remove_handler(getlogger(), "testhandler")
+                    @test_warn(
+                        "`remove_handler(logger, name)` is being deprecated.",
+                        remove_handler(getlogger(), "testhandler")
+                    )
+                end
             finally
                 close(io)
             end
@@ -160,22 +162,24 @@
                 )
 
                 # Can't properly test subsequent deprecations because of
-                # https://github.com/JuliaLang/julia/issues/22043
+                # https://github.com/JuliaLang/julia/issues/22043, but should be fixed by
+                # https://github.com/JuliaLang/julia/pull/24490
+                if VERSION >= v"0.7.0-DEV.2988"
+                    @test_warn(
+                        "filters(handler::DefaultHandler) is deprecated, use getfilters(handler::DefaultHandler) instead.",
+                        filters(handler)
+                    )
 
-                # @test_warn(
-                #     "filters(handler::DefaultHandler) is deprecated, use getfilters(handler::DefaultHandler) instead.",
-                #     filters(handler)
-                # )
+                    @test_warn(
+                        "add_filter(handler::DefaultHandler, filter::Memento.Filter) is deprecated, use push!(handler::DefaultHandler, filter::Memento.Filter) instead.",
+                        add_filter(handler, Memento.Filter(handler))
+                    )
 
-                # @test_warn(
-                #     "add_filter(handler::DefaultHandler, filter::Memento.Filter) is deprecated, use push!(handler::DefaultHandler, filter::Memento.Filter) instead.",
-                #     add_filter(handler, Memento.Filter(handler))
-                # )
-
-                # @test_warn(
-                #     "set_level(handler::DefaultHandler, level::AbstractString) is deprecated, use setlevel!(handler::DefaultHandler, level::AbstractString) instead.",
-                #     set_level(handler, "info")
-                # )
+                    @test_warn(
+                        "set_level(handler::DefaultHandler, level::AbstractString) is deprecated, use setlevel!(handler::DefaultHandler, level::AbstractString) instead.",
+                        set_level(handler, "info")
+                    )
+                end
             finally
                 close(io)
             end

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -61,127 +61,119 @@
             io = IOBuffer()
             handler = DefaultHandler(io, DefaultFormatter(FMT_STR))
 
-            try
-                # Can't properly test subsequent deprecations because of
-                # https://github.com/JuliaLang/julia/issues/22043, but should be fixed by
-                # https://github.com/JuliaLang/julia/pull/24490
-                if VERSION < v"0.7.0-DEV.2988"
-                    @suppress add_handler(getlogger(), handler, "testhandler")
-                    @suppress remove_handler(getlogger(), "testhandler")
-                else
-                    logger = @test_warn(
-                        "get_logger(name) is deprecated, use getlogger(name) instead.",
-                        get_logger("Logger.example")
-                    )
+            # Can't properly test subsequent deprecations because of
+            # https://github.com/JuliaLang/julia/issues/22043, but should be fixed by
+            # https://github.com/JuliaLang/julia/pull/24490
+            if VERSION < v"0.7.0-DEV.2988"
+                @suppress add_handler(getlogger(), handler, "testhandler")
+                @suppress remove_handler(getlogger(), "testhandler")
+            else
+                logger = @test_warn(
+                    "get_logger(name) is deprecated, use getlogger(name) instead.",
+                    get_logger("Logger.example")
+                )
 
-                    @test_warn(
-                        "is_root(logger::Logger) is deprecated, use isroot(logger::Logger) instead.",
-                        is_root(logger)
-                    )
+                @test_warn(
+                    "is_root(logger::Logger) is deprecated, use isroot(logger::Logger) instead.",
+                    is_root(logger)
+                )
 
-                    @test_warn(
-                        "is_set(logger::Logger) is deprecated, use isset(logger::Logger) instead.",
-                        is_set(logger)
-                    )
+                @test_warn(
+                    "is_set(logger::Logger) is deprecated, use isset(logger::Logger) instead.",
+                    is_set(logger)
+                )
 
-                    @test_warn(
-                        "get_level(logger::Logger) is deprecated, use getlevel(logger::Logger) instead.",
-                        get_level(logger)
-                    )
+                @test_warn(
+                    "get_level(logger::Logger) is deprecated, use getlevel(logger::Logger) instead.",
+                    get_level(logger)
+                )
 
-                    @test_warn(
-                        "get_parent(logger::Logger) is deprecated, use getparent(logger::Logger) instead.",
-                        getparent(logger)
-                    )
+                @test_warn(
+                    "get_parent(logger::Logger) is deprecated, use getparent(logger::Logger) instead.",
+                    getparent(logger)
+                )
 
-                    @test_warn(
-                        "set_record(logger::Logger, rec) is deprecated, use setrecord!(logger::Logger, rec) instead.",
-                        setrecord!(logger, DefaultRecord)
-                    )
+                @test_warn(
+                    "set_record(logger::Logger, rec) is deprecated, use setrecord!(logger::Logger, rec) instead.",
+                    setrecord!(logger, DefaultRecord)
+                )
 
-                    @test_warn(
-                        "filters(logger::Logger) is deprecated, use getfilters(logger::Logger) instead.",
-                        filters(logger)
-                    )
+                @test_warn(
+                    "filters(logger::Logger) is deprecated, use getfilters(logger::Logger) instead.",
+                    filters(logger)
+                )
 
-                    @test_warn(
-                        "add_filter(logger::Logger, filter::Memento.Filter) is deprecated, use push!(logger::Logger, filter::Memento.Filter) instead.",
-                        add_filter(logger, Memento.Filter(logger))
-                    )
+                @test_warn(
+                    "add_filter(logger::Logger, filter::Memento.Filter) is deprecated, use push!(logger::Logger, filter::Memento.Filter) instead.",
+                    add_filter(logger, Memento.Filter(logger))
+                )
 
-                    @test_warn(
-                        "get_handlers(logger::Logger) is deprecated, use gethandlers(logger::Logger) instead.",
-                        get_handlers(logger)
-                    )
+                @test_warn(
+                    "get_handlers(logger::Logger) is deprecated, use gethandlers(logger::Logger) instead.",
+                    get_handlers(logger)
+                )
 
-                    @test_warn(
-                        "add_level(logger::Logger, level, val) is deprecated, use addlevel!(logger::Logger, level, val) instead.",
-                        add_level(logger, "testlevel", 89)
-                    )
+                @test_warn(
+                    "add_level(logger::Logger, level, val) is deprecated, use addlevel!(logger::Logger, level, val) instead.",
+                    add_level(logger, "testlevel", 89)
+                )
 
-                    @test_warn(
-                        "set_level(logger::Logger, level) is deprecated, use setlevel!(logger::Logger, level) instead.",
-                        set_level(logger, "info")
-                    )
+                @test_warn(
+                    "set_level(logger::Logger, level) is deprecated, use setlevel!(logger::Logger, level) instead.",
+                    set_level(logger, "info")
+                )
 
-                    @test_warn(
-                        "set_level(f::Function, logger::Logger, level) is deprecated, use setlevel!(f::Function, logger::Logger, level) instead.",
-                        set_level(logger, "error") do
-                            warn(logger, "silenced message should not be displayed")
-                        end
-                    )
+                @test_warn(
+                    "set_level(f::Function, logger::Logger, level) is deprecated, use setlevel!(f::Function, logger::Logger, level) instead.",
+                    set_level(logger, "error") do
+                        warn(logger, "silenced message should not be displayed")
+                    end
+                )
 
-                    @test_warn(
-                        "`add_handler(logger, handler[, name])` is being deprecated in favour of `push!(logger, handler)`",
-                        add_handler(getlogger(), handler, "testhandler")
-                    )
+                @test_warn(
+                    "`add_handler(logger, handler[, name])` is being deprecated in favour of `push!(logger, handler)`",
+                    add_handler(getlogger(), handler, "testhandler")
+                )
 
-                    @test_warn(
-                        "`remove_handler(logger, name)` is being deprecated.",
-                        remove_handler(getlogger(), "testhandler")
-                    )
-                end
-            finally
-                close(io)
+                @test_warn(
+                    "`remove_handler(logger, name)` is being deprecated.",
+                    remove_handler(getlogger(), "testhandler")
+                )
             end
         end
 
         @testset "Handler" begin
             io = IOBuffer()
 
-            try
-                handler = DefaultHandler(io, DefaultFormatter(FMT_STR))
+            handler = DefaultHandler(io, DefaultFormatter(FMT_STR))
 
-                logger = Logger(
-                    "DefaultHandler.sample_io",
-                    Dict("Buffer" => handler),
-                    "info",
-                    LEVELS,
-                    DefaultRecord,
-                    true
+            logger = Logger(
+                "DefaultHandler.sample_io",
+                Dict("Buffer" => handler),
+                "info",
+                LEVELS,
+                DefaultRecord,
+                true
+            )
+
+            # Can't properly test subsequent deprecations because of
+            # https://github.com/JuliaLang/julia/issues/22043, but should be fixed by
+            # https://github.com/JuliaLang/julia/pull/24490
+            if VERSION >= v"0.7.0-DEV.2988"
+                @test_warn(
+                    "filters(handler::DefaultHandler) is deprecated, use getfilters(handler::DefaultHandler) instead.",
+                    filters(handler)
                 )
 
-                # Can't properly test subsequent deprecations because of
-                # https://github.com/JuliaLang/julia/issues/22043, but should be fixed by
-                # https://github.com/JuliaLang/julia/pull/24490
-                if VERSION >= v"0.7.0-DEV.2988"
-                    @test_warn(
-                        "filters(handler::DefaultHandler) is deprecated, use getfilters(handler::DefaultHandler) instead.",
-                        filters(handler)
-                    )
+                @test_warn(
+                    "add_filter(handler::DefaultHandler, filter::Memento.Filter) is deprecated, use push!(handler::DefaultHandler, filter::Memento.Filter) instead.",
+                    add_filter(handler, Memento.Filter(handler))
+                )
 
-                    @test_warn(
-                        "add_filter(handler::DefaultHandler, filter::Memento.Filter) is deprecated, use push!(handler::DefaultHandler, filter::Memento.Filter) instead.",
-                        add_filter(handler, Memento.Filter(handler))
-                    )
-
-                    @test_warn(
-                        "set_level(handler::DefaultHandler, level::AbstractString) is deprecated, use setlevel!(handler::DefaultHandler, level::AbstractString) instead.",
-                        set_level(handler, "info")
-                    )
-                end
-            finally
-                close(io)
+                @test_warn(
+                    "set_level(handler::DefaultHandler, level::AbstractString) is deprecated, use setlevel!(handler::DefaultHandler, level::AbstractString) instead.",
+                    set_level(handler, "info")
+                )
             end
         end
     end

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,47 +1,184 @@
-@testset "v0.4 deprecations" begin
-    if Sys.isunix()
-        @testset "Syslog" begin
-            levels = copy(Memento._log_levels)
-            levels["invalid"] = 100
+@testset "Deprecations" begin
+    @testset "Memento v0.4" begin
+        if Sys.isunix()
+            @testset "Syslog" begin
+                levels = copy(Memento._log_levels)
+                levels["invalid"] = 100
 
-            # Create our DefaultHandler w/ the Syslog IO type
-            handler = @test_warn(
-                "Syslog has been moved to Syslogs.jl",
-                DefaultHandler(Memento.Syslog(), DefaultFormatter("{level}: {msg}"))
+                # Create our DefaultHandler w/ the Syslog IO type
+                handler = @test_warn(
+                    "Syslog has been moved to Syslogs.jl",
+                    DefaultHandler(Memento.Syslog(), DefaultFormatter("{level}: {msg}"))
+                )
+
+                logger = Logger(
+                    "Deprecated",
+                    Dict("Syslog" => handler),
+                    "debug",
+                    levels,
+                    DefaultRecord,
+                    true
+                )
+
+                # We just want to test that our glue code works with Syslogs.jl
+                @test_warn(
+                    "The custom `Memento.emit` method for Syslog IO types will not be provided in the future.",
+                    info(logger, "Hello World!")
+                )
+            end
+        end
+
+        @testset "JsonFormatter" begin
+            rec = DefaultRecord("Logger.example", "info", 20, "blah")
+
+            fmt = @test_warn(
+                "JsonFormatter(aliases=Nullable()) is deprecated, use DictFormatter(aliases, JSON.json) instead.",
+                JsonFormatter()
             )
 
-            logger = Logger(
-                "Deprecated",
-                Dict("Syslog" => handler),
-                "debug",
-                levels,
-                DefaultRecord,
-                true
-            )
+            result = Memento.format(fmt, rec)
+            @test isa(JSON.parse(result), Dict)
 
-            # We just want to test that our glue code works with Syslogs.jl
-            @test_warn(
-                "The custom `Memento.emit` method for Syslog IO types will not be provided in the future.",
-                info(logger, "Hello World!")
-            )
+            for key in [:date, :name, :level, :lookup, :stacktrace, :msg]
+                @test contains(result, string(key))
+            end
+
+            @test contains(result, "blah")
         end
     end
 
-    @testset "JsonFormatter" begin
-        rec = DefaultRecord("Logger.example", "info", 20, "blah")
-
-        fmt = @test_warn(
-            "JsonFormatter(aliases=Nullable()) is deprecated, use DictFormatter(aliases, JSON.json) instead.",
-            JsonFormatter()
+    @testset "Memento v0.5" begin
+        FMT_STR = "[{level}]:{name} - {msg}"
+        LEVELS = Dict(
+            "not_set" => 0,
+            "debug" => 10,
+            "info" => 20,
+            "warn" => 30,
+            "error" => 40,
         )
 
-        result = Memento.format(fmt, rec)
-        @test isa(JSON.parse(result), Dict)
+        @testset "Logger" begin
+            io = IOBuffer()
+            handler = DefaultHandler(io, DefaultFormatter(FMT_STR))
 
-        for key in [:date, :name, :level, :lookup, :stacktrace, :msg]
-            @test contains(result, string(key))
+            try
+                # Can't properly test subsequent deprecations because of
+                # https://github.com/JuliaLang/julia/issues/22043
+
+                # logger = @test_warn(
+                #     "get_logger(name) is deprecated, use getlogger(name) instead.",
+                #     get_logger("Logger.example")
+                # )
+
+                # @test_warn(
+                #     "is_root(logger::Logger) is deprecated, use isroot(logger::Logger) instead.",
+                #     is_root(logger)
+                # )
+
+                # @test_warn(
+                #     "is_set(logger::Logger) is deprecated, use isset(logger::Logger) instead.",
+                #     is_set(logger)
+                # )
+
+                # @test_warn(
+                #     "get_level(logger::Logger) is deprecated, use getlevel(logger::Logger) instead.",
+                #     get_level(logger)
+                # )
+
+                # @test_warn(
+                #     "get_parent(logger::Logger) is deprecated, use getparent(logger::Logger) instead.",
+                #     getparent(logger)
+                # )
+
+                # @test_warn(
+                #     "set_record(logger::Logger, rec) is deprecated, use setrecord!(logger::Logger, rec) instead.",
+                #     setrecord!(logger, DefaultRecord)
+                # )
+
+                # @test_warn(
+                #     "filters(logger::Logger) is deprecated, use getfilters(logger::Logger) instead.",
+                #     filters(logger)
+                # )
+
+                # @test_warn(
+                #     "add_filter(logger::Logger, filter::Memento.Filter) is deprecated, use push!(logger::Logger, filter::Memento.Filter) instead.",
+                #     add_filter(logger, Memento.Filter(logger))
+                # )
+
+                # @test_warn(
+                #     "get_handlers(logger::Logger) is deprecated, use gethandlers(logger::Logger) instead.",
+                #     get_handlers(logger)
+                # )
+
+                # @test_warn(
+                #     "add_level(logger::Logger, level, val) is deprecated, use addlevel!(logger::Logger, level, val) instead.",
+                #     add_level(logger, "testlevel", 89)
+                # )
+
+                # @test_warn(
+                #     "set_level(logger::Logger, level) is deprecated, use setlevel!(logger::Logger, level) instead.",
+                #     set_level(logger, "info")
+                # )
+
+                # @test_warn(
+                #     "set_level(f::Function, logger::Logger, level) is deprecated, use setlevel!(f::Function, logger::Logger, level) instead.",
+                #     set_level(logger, "error") do
+                #         warn(logger, "silenced message should not be displayed")
+                #     end
+                # )
+
+                # @test_warn(
+                #     "`add_handler(logger, handler[, name])` is being deprecated in favour of `push!(logger, handler)`",
+                #     add_handler(getlogger(), handler, "testhandler")
+                # )
+                @suppress add_handler(getlogger(), handler, "testhandler")
+
+                # @test_warn(
+                #     "`remove_handler(logger, name)` is being deprecated.",
+                #     remove_handler(getlogger(), "testhandler")
+                # )
+
+                @suppress remove_handler(getlogger(), "testhandler")
+            finally
+                close(io)
+            end
         end
 
-        @test contains(result, "blah")
+        @testset "Handler" begin
+            io = IOBuffer()
+
+            try
+                handler = DefaultHandler(io, DefaultFormatter(FMT_STR))
+
+                logger = Logger(
+                    "DefaultHandler.sample_io",
+                    Dict("Buffer" => handler),
+                    "info",
+                    LEVELS,
+                    DefaultRecord,
+                    true
+                )
+
+                # Can't properly test subsequent deprecations because of
+                # https://github.com/JuliaLang/julia/issues/22043
+
+                # @test_warn(
+                #     "filters(handler::DefaultHandler) is deprecated, use getfilters(handler::DefaultHandler) instead.",
+                #     filters(handler)
+                # )
+
+                # @test_warn(
+                #     "add_filter(handler::DefaultHandler, filter::Memento.Filter) is deprecated, use push!(handler::DefaultHandler, filter::Memento.Filter) instead.",
+                #     add_filter(handler, Memento.Filter(handler))
+                # )
+
+                # @test_warn(
+                #     "set_level(handler::DefaultHandler, level::AbstractString) is deprecated, use setlevel!(handler::DefaultHandler, level::AbstractString) instead.",
+                #     set_level(handler, "info")
+                # )
+            finally
+                close(io)
+            end
+        end
     end
 end

--- a/test/ext/syslogs.jl
+++ b/test/ext/syslogs.jl
@@ -38,7 +38,7 @@ end
     )
 
     # We just want to test that our glue code works with Syslogs.jl
-    info(logger, "Hello World!")
+    @suppress info(logger, "Hello World!")
     s = fetch(r)
     @test contains(s, "Hello World!")
 end

--- a/test/handlers.jl
+++ b/test/handlers.jl
@@ -15,9 +15,7 @@
             io = IOBuffer()
 
             try
-                handler = DefaultHandler(
-                    io, DefaultFormatter(FMT_STR)
-                )
+                handler = DefaultHandler(io, DefaultFormatter(FMT_STR))
 
                 logger = Logger(
                     "DefaultHandler.sample_io",
@@ -171,9 +169,7 @@
             io = IOBuffer()
 
             try
-                handler = DefaultHandler(
-                    io, DefaultFormatter(FMT_STR)
-                )
+                handler = DefaultHandler(io, DefaultFormatter(FMT_STR))
 
                 logger = Logger(
                     "DefaultHandler.sample_io",
@@ -192,7 +188,7 @@
                 @test contains(String(take!(io)), "[info]:$(logger.name) - $msg")
 
                 # Filter out log messages < LEVELS["warn"]
-                set_level(handler, "warn")
+                setlevel!(handler, "warn")
                 # add_filter(
                 #     handler,
                 #     Filter((rec) -> rec[:levelnum] >= LEVELS["warn"])

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -41,6 +41,9 @@ end
             setlevel!(logger, "info")
             @test logger.level == "info"
 
+            push!(logger, Memento.Filter(logger))
+            @test length(getfilters(logger)) == 3
+
             setlevel!(logger, "error") do
                 @test getlevel(logger) == "error"
                 warn(logger, "silenced message should not be displayed")

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -32,7 +32,7 @@ end
             @test logger.level == "error"
             @test length(gethandlers(logger)) == 1
 
-            logger += DefaultHandler(tempname())
+            push!(logger, DefaultHandler(tempname()))
             @test length(gethandlers(logger)) == 2
 
             @test ispropagating(logger)
@@ -104,7 +104,7 @@ end
             @test logger.level == "error"
             @test length(gethandlers(logger)) == 1
 
-            logger += DefaultHandler(tempname())
+            push!(logger, DefaultHandler(tempname()))
             @test length(gethandlers(logger)) == 2
 
             setlevel!(logger, "info")

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -17,9 +17,7 @@ end
         io = IOBuffer()
 
         try
-            handler = DefaultHandler(
-                io, DefaultFormatter(FMT_STR)
-            )
+            handler = DefaultHandler(io, DefaultFormatter(FMT_STR))
 
             logger = Logger(
                 "Logger.example",
@@ -32,26 +30,26 @@ end
 
             @test logger.name == "Logger.example"
             @test logger.level == "error"
-            @test length(get_handlers(logger)) == 1
+            @test length(gethandlers(logger)) == 1
 
-            add_handler(logger, DefaultHandler(tempname()), "filehandler")
-            @test length(get_handlers(logger)) == 2
+            logger += DefaultHandler(tempname())
+            @test length(gethandlers(logger)) == 2
 
-            remove_handler(logger, "filehandler")
-            @test length(get_handlers(logger)) == 1
+            @test ispropagating(logger)
+            @test setpropagating!(logger, true)
 
-            set_level(logger, "info")
+            setlevel!(logger, "info")
             @test logger.level == "info"
 
-            set_level(logger, "error") do
-                @test get_level(logger) == "error"
+            setlevel!(logger, "error") do
+                @test getlevel(logger) == "error"
                 warn(logger, "silenced message should not be displayed")
             end
-            @test get_level(logger) == "info"
+            @test getlevel(logger) == "info"
 
-            set_record(logger, DefaultRecord)
+            setrecord!(logger, DefaultRecord)
 
-            add_level(logger, "fubar", 50)
+            addlevel!(logger, "fubar", 50)
 
             show(io, logger)
             @test contains(String(take!(io)), "Logger(Logger.example)")
@@ -88,9 +86,7 @@ end
         io = IOBuffer()
 
         try
-            handler = DefaultHandler(
-                io, DefaultFormatter(FMT_STR)
-            )
+            handler = DefaultHandler(io, DefaultFormatter(FMT_STR))
 
             logger = Logger(
                 "Logger.example",
@@ -103,19 +99,16 @@ end
 
             @test logger.name == "Logger.example"
             @test logger.level == "error"
-            @test length(get_handlers(logger)) == 1
+            @test length(gethandlers(logger)) == 1
 
-            add_handler(logger, DefaultHandler(tempname()), "filehandler")
-            @test length(get_handlers(logger)) == 2
+            logger += DefaultHandler(tempname())
+            @test length(gethandlers(logger)) == 2
 
-            remove_handler(logger, "filehandler")
-            @test length(get_handlers(logger)) == 1
-
-            set_level(logger, "info")
+            setlevel!(logger, "info")
             @test logger.level == "info"
 
-            set_record(logger, DefaultRecord)
-            add_level(logger, "fubar", 50)
+            setrecord!(logger, DefaultRecord)
+            addlevel!(logger, "fubar", 50)
 
             show(io, logger)
             @test contains(String(take!(io)), "Logger(Logger.example)")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,7 +62,7 @@ cd(dirname(@__FILE__))
             @test contains(result, expected)
 
             setlevel!(baz, "debug")
-            baz += DefaultHandler(io, DefaultFormatter("{name} - {level}: {msg}"))
+            push!(baz, DefaultHandler(io, DefaultFormatter("{name} - {level}: {msg}")))
 
             msg = "Message"
             warn(baz, msg)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Compat
 using Compat.Test
+using Suppressor
 
 import Compat: Dates
 import Compat:Sys
@@ -25,38 +26,34 @@ cd(dirname(@__FILE__))
 @testset "Logging" begin
     @testset "Sample Usage" begin
         Memento.config("info"; fmt="[{date} | {level} | {name}]: {msg}", colorized=false)
-        logger1 = get_logger(@__MODULE__)
+        logger1 = getlogger(@__MODULE__)
         debug(logger1, "Something that won't get logged.")
         info(logger1, "Something you might want to know.")
         warn(logger1, "This might cause an error.")
         warn(logger1, ErrorException("A caught exception that we want to log as a warning."))
         @test_throws ErrorException error(logger1, "Something that should throw an error.")
         @test_throws ErrorException error(logger1, ErrorException("A caught exception that we should log and rethrow"))
-        logger2 = get_logger("Pkg.Foo.Bar")
+        logger2 = getlogger("Pkg.Foo.Bar")
     end
 
     @testset "Logger Hierarchy" begin
         Memento.reset!()
-        foo = get_logger("Foo")
-        bar = get_logger("Foo.Bar")
-        baz = get_logger("Foo.Bar.Baz")
-        car = get_logger("Foo.Car")
+        foo = getlogger("Foo")
+        bar = getlogger("Foo.Bar")
+        baz = getlogger("Foo.Bar.Baz")
+        car = getlogger("Foo.Car")
 
         for l in (foo, bar, baz, car)
-            @test is_set(l)
-            @test get_level(l) == "warn"
-            @test length(get_handlers(l)) == 0
+            @test isset(l)
+            @test getlevel(l) == "warn"
+            @test length(gethandlers(l)) == 0
         end
 
         io = IOBuffer()
 
         try
-            set_level(get_logger(), "info")
-            add_handler(
-                get_logger(),
-                DefaultHandler(io, DefaultFormatter("{name} - {level}: {msg}")),
-                "io"
-            )
+            setlevel!(getlogger(), "info")
+            push!(getlogger(), DefaultHandler(io, DefaultFormatter("{name} - {level}: {msg}")))
 
             msg = "This should propagate to the root logger."
             warn(baz, msg)
@@ -64,12 +61,8 @@ cd(dirname(@__FILE__))
             expected = "Foo.Bar.Baz - warn: $msg"
             @test contains(result, expected)
 
-            set_level(baz, "debug")
-            add_handler(
-                baz,
-                DefaultHandler(io, DefaultFormatter("{name} - {level}: {msg}")),
-                "io"
-            )
+            setlevel!(baz, "debug")
+            baz += DefaultHandler(io, DefaultFormatter("{name} - {level}: {msg}"))
 
             msg = "Message"
             warn(baz, msg)


### PR DESCRIPTION
Closes #31 

Main changes include:

1. Removing `_` from public method names
2. Adding `!` to mutating methods
3. Removing `add_handler` and `remove_handler` in favour of `push!(logger, handler)`. I'll be replacing the internal handler `Dict` with a `Vector` in a future release.
4. Overloaded `+=` for adding handlers and filters to loggers (or filters to handlers).