### PR TITLE
Updated propagation rules

### DIFF
--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -320,10 +320,10 @@ function log(logger::Logger, rec::Record)
         for (name, handler) in logger.handlers
             @async log(handler, rec)
         end
-    end
 
-    if !isroot(logger) && logger.propagate
-        log(getparent(logger.name), rec)
+        if !isroot(logger) && logger.propagate
+            log(getparent(logger.name), rec)
+        end
     end
 end
 


### PR DESCRIPTION
Now a log record must pass all filters for a logger before attempting to propagate up the hierarchy
which should more closely align with what python does. This should make it easier to silence noisy
packages at the cost of making it a bit more tedious to get lower priority messages (e.g., `debug`, `info`, `notice`)
from child loggers. Getting lower priority messages from child loggers now requires that you either
change the level for each logger along the chain... or add a specific handler to the child logger.

Closes #42 