### PR TITLE
Add special handling for CompositeException

### DIFF
--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -410,6 +410,13 @@ for key in keys(_log_levels)
                     log(logger, $key, sprint(io -> showerror(io, exc)))
                     throw(exc)
                 end
+
+                function $level(logger::Logger, exc::CompositeException)
+                    for sub_exc in exc
+                        log(logger, $key, sprint(io -> showerror(io, sub_exc)))
+                    end
+                    throw(exc)
+                end
             end
             f = eval(level)
         end
@@ -444,7 +451,8 @@ Logs the message produced by the provided function at the $level level and throw
 
     $level(logger::Logger, exc::Exception)
 
-Calls `$level(logger, msg)` with the contents of the `Exception`.
+Calls `$level(logger, msg)` with the contents of the `Exception`, then throw the `Exception`.
+If the exception is a `CompositeException`, each contained exception is logged, then the `CompositeException` is thrown.
 """
 
 @doc msg("error") error
@@ -456,7 +464,14 @@ Calls `$level(logger, msg)` with the contents of the `Exception`.
     warn(logger::Logger, exc::Exception)
 
 Takes an exception and logs it.
+If the exception is a `CompositeException`, each contained exception is logged.
 """
 function warn(logger::Logger, exc::Exception)
     log(logger, "warn", sprint(io -> showerror(io, exc)))
+end
+
+function warn(logger::Logger, exc::CompositeException)
+    for sub_exc in exc
+        log(logger, "warn", sprint(io -> showerror(io, sub_exc)))
+    end
 end

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -63,6 +63,25 @@
             @test_throws TestError Memento.error(logger, TestError("I failed."))
             @test contains(String(take!(io)), "I failed")
 
+            # CompositeException
+            comp = CompositeException([
+                ErrorException("I am the first error"),
+                ArgumentError("I am the second error"),
+            ])
+            @test_throws CompositeException Memento.error(logger, comp)
+            output = String(take!(io))
+            @test contains(output, "I am the first error")
+            @test contains(output, "I am the second error")
+
+            comp = CompositeException([
+                ArgumentError("Error numero uno"),
+                ErrorException("Error numero dos"),
+            ])
+            Memento.warn(logger, comp)
+            output = String(take!(io))
+            @test contains(output, "Error numero uno")
+            @test contains(output, "Error numero dos")
+
             msg = "Something went very wrong"
             log(logger, "fubar", msg)
             @test contains(String(take!(io)), "[fubar]:Logger.example - $msg")


### PR DESCRIPTION
This will log each exception separately, but throw the CompositeException.

Julia just prints the first exception in a CompositeException and then says "and x other errors". This is more helpful/complete.