### PR TITLE
Silence logging test macros

### DIFF
--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -102,11 +102,22 @@ Returns true or false as to whether the logger is propagating.
 ispropagating(logger::Logger) = logger.propagate
 
 """
-    setpropagating!(::Logger, [::Bool])
+    setpropagating!([::Function], ::Logger, [::Bool])
 
 Sets the logger to be propagating or not (Defaults to true).
 """
 setpropagating!(logger::Logger, val::Bool=true) = logger.propagate = val
+
+function setpropagating!(f::Function, logger::Logger, val::Bool=true)
+    init_val = logger.propagate
+    logger.propagate = val
+
+    try
+        f()
+    finally
+        logger.propagate = init_val
+    end
+end
 
 """
     getlevel(::Logger)


### PR DESCRIPTION
`@test_log` and related functions should be properly disabled while running the testing code. This includes dropping any existing handlers and not allowing the logger to propagate.