### PR TITLE
Add recursive keyword arguments to `config` and `setlevel!`

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
-Compat 0.54.0
+Compat 0.61.0
 Syslogs 0.0.1
 JSON 0.16.1
 Nullables 0.0.3


### PR DESCRIPTION
Between broadcasting `setlevel` calls and the recursive flag it should be much easier to customize the logging levels in the logger hierarchy. Closes #58 .