### PR TITLE
Rename `config` to `config!` since we're directly mutating loggers now

### DIFF
--- a/docs/quickstart.jl
+++ b/docs/quickstart.jl
@@ -1,7 +1,7 @@
 # Copy and paste these line into a REPL and screen capture to produce the
 # sample usage image.
 using Memento
-logger = Memento.config("debug"; fmt="[{level} | {name}]: {msg}")
+logger = Memento.config!("debug"; fmt="[{level} | {name}]: {msg}")
 debug(logger, "Something to help you track down a bug.")
 info(logger, "Something you might want to know.")
 notice(logger, "This is probably pretty important.")

--- a/docs/src/faq/change-colors.md
+++ b/docs/src/faq/change-colors.md
@@ -40,7 +40,7 @@ add_handler(logger, DefaultHandler(
     "console"
 )
 ```
-You can also globally disable colorization when running `Memento.config`
+You can also globally disable colorization when running `Memento.config!`
 ```julia
-julia> Memento.config("info"; fmt="[{date} | {level} | {name}]: {msg}", colorized=false)
+julia> Memento.config!("info"; fmt="[{date} | {level} | {name}]: {msg}", colorized=false)
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,9 +19,9 @@ Start by `using` Memento
 julia> using Memento
 ```
 
-Now setup basic logging on the root logger with `Memento.config`.
+Now setup basic logging on the root logger with `Memento.config!`.
 ```julia
-julia> logger = Memento.config("debug"; fmt="[{level} | {name}]: {msg}")
+julia> logger = Memento.config!("debug"; fmt="[{level} | {name}]: {msg}")
 Logger(root)
 ```
 Now start logging with the root logger.

--- a/docs/src/man/conclusion.md
+++ b/docs/src/man/conclusion.md
@@ -55,7 +55,7 @@ using Memento
 using Requests  # For send logs to our fake logging REST service
 
 # Start by setting up our basic console logging for the root logger.
-logger = Memento.config("info"; fmt="[{level} | {name}]: {msg}")
+logger = Memento.config!("info"; fmt="[{level} | {name}]: {msg}")
 
 # We create our custom EC2Record type
 mutable struct EC2Record <: Record

--- a/docs/src/man/intro.md
+++ b/docs/src/man/intro.md
@@ -2,13 +2,13 @@
 
 ## Logging levels
 
-You can globally set the minimum logging level with `Memento.config`.
+You can globally set the minimum logging level with `Memento.config!`.
 ```julia
-julia>Memento.config("debug")
+julia>Memento.config!("debug")
 ```
 Will log all messages for all loggers at or above "debug".
 ```julia
-julia>Memento.config("warn")
+julia>Memento.config!("warn")
 ```
 Will only log message at or above the "warn" level.
 
@@ -51,9 +51,9 @@ warn: my warning message.
 ...
 ```
 
-The simplest way to globally change the log format is with `Memento.config`
+The simplest way to globally change the log format is with `Memento.config!`
 ```julia
-julia> Memento.config("debug"; fmt="[{level} | {name}]: {msg}")
+julia> Memento.config!("debug"; fmt="[{level} | {name}]: {msg}")
 ```
 
 The following fields are available via the `DefaultRecord`.

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -44,6 +44,7 @@ include("handlers.jl")
 include("loggers.jl")
 include("syslog.jl")
 include("test.jl")
+include("deprecated.jl")
 
 # Initializing at compile-time will work as long as the loggers which are added do not
 # contain references to STDOUT.
@@ -52,7 +53,7 @@ const _loggers = Dict{AbstractString, Logger}(
 )
 
 function __init__()
-    Memento.config("warn")
+    Memento.config!("warn")
 end
 
 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,1 @@
+@deprecate config(args...; kwargs...) config!(args...; kwargs...)

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -123,7 +123,7 @@ Register an existing logger with Memento.
 register(logger::Logger) = _loggers[logger.name] = logger
 
 """
-    config([logger], level; fmt::AbstractString, levels::Dict{AbstractString, Int}, colorized::Bool) -> Logger
+    config!([logger], level; fmt::AbstractString, levels::Dict{AbstractString, Int}, colorized::Bool) -> Logger
 
 Sets the `Memento._log_levels`, creates a default root logger with a `DefaultHandler`
 that prints to STDOUT.
@@ -139,13 +139,13 @@ that prints to STDOUT.
 # Returns
 * `Logger`: the root logger.
 """
-config(level::AbstractString; kwargs...) = config(Logger("root"), level; kwargs...)
+config!(level::AbstractString; kwargs...) = config!(Logger("root"), level; kwargs...)
 
-function config(logger::AbstractString, level::AbstractString; kwargs...)
-    config(Logger(logger), level; kwargs...)
+function config!(logger::AbstractString, level::AbstractString; kwargs...)
+    config!(Logger(logger), level; kwargs...)
 end
 
-function config(logger::Logger, level::AbstractString; fmt::AbstractString=DEFAULT_FMT_STRING, levels=_log_levels, colorized=true)
+function config!(logger::Logger, level::AbstractString; fmt::AbstractString=DEFAULT_FMT_STRING, levels=_log_levels, colorized=true)
     logger.levels = levels
     setlevel!(logger, level)
     handler = DefaultHandler(

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -149,17 +149,17 @@
     end
 
     @testset "Memento.config" begin
-        root_logger = Memento.config(
+        root_logger = Memento.config!(
             "info";
             fmt="[{date} | {level} | {name}]: {msg}", colorized=false
         )
 
-        my_logger = Memento.config(
+        my_logger = Memento.config!(
             getlogger("MyLogger"), "info";
             fmt="[{date} | {level} | {name}]: {msg}", colorized=false
         )
 
-        str_logger = Memento.config(
+        str_logger = Memento.config!(
             "StrLogger", "info";
             fmt="[{date} | {level} | {name}]: {msg}", colorized=false
         )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,7 +34,7 @@ end
 
 @testset "Logging" begin
     @testset "Sample Usage" begin
-        Memento.config("info"; fmt="[{date} | {level} | {name}]: {msg}", colorized=false)
+        Memento.config!("info"; fmt="[{date} | {level} | {name}]: {msg}", colorized=false)
         logger1 = getlogger(@__MODULE__)
         debug(logger1, "Something that won't get logged.")
         info(logger1, "Something you might want to know.")


### PR DESCRIPTION
Closes #73 