### PR TITLE
Replacing base logging

### DIFF
--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -45,6 +45,7 @@ include("formatters.jl")
 include("handlers.jl")
 include("loggers.jl")
 include("syslog.jl")
+include("stdlib.jl")
 include("test.jl")
 include("deprecated.jl")
 

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -9,7 +9,6 @@ using Compat.Dates
 using Compat.Sockets
 using Compat.Distributed
 
-import Compat: @__MODULE__
 import Syslogs
 import JSON
 using Nullables

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -9,6 +9,7 @@ using Compat.Dates
 using Compat.Sockets
 using Compat.Distributed
 
+import Compat: @__MODULE__
 import Syslogs
 import JSON
 using Nullables
@@ -46,6 +47,7 @@ include("handlers.jl")
 include("loggers.jl")
 include("syslog.jl")
 include("stdlib.jl")
+include("config.jl")
 include("test.jl")
 include("deprecated.jl")
 

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,0 +1,59 @@
+
+"""
+    config!([logger], level; fmt::AbstractString, levels::Dict{AbstractString, Int}, colorized::Bool) -> Logger
+
+Sets the `Memento._log_levels`, creates a default root logger with a `DefaultHandler`
+that prints to stdout.
+
+# Arguments
+* 'logger::Union{Logger, AbstractString}`: The logger to configure (optional)
+* `level::AbstractString`: the minimum logging level to log message to the root logger (required).
+
+# Keywords
+* `fmt::AbstractString`: a format string to pass to the `DefaultFormatter` which describes
+    how to log messages (defaults to `Memento.DEFAULT_FMT_STRING`)
+* `levels`: the default logging levels to use (defaults to `Memento._log_levels`).
+* `colorized`: whether or not the message to stdout should be colorized.
+* `recursive`: whether or not to recursive set the level of all child loggers.
+* `substitute`: whether or not to substitute the global logger with Memento
+  (only supported on julia 0.7).
+
+# Returns
+* `Logger`: the root logger.
+"""
+config!(level::AbstractString; kwargs...) = config!(Logger("root"), level; kwargs...)
+
+function config!(logger::AbstractString, level::AbstractString; kwargs...)
+    config!(Logger(logger), level; kwargs...)
+end
+
+function config!(
+    logger::Logger, level::AbstractString;
+    fmt::AbstractString=DEFAULT_FMT_STRING, levels=_log_levels, colorized=true,
+    recursive=false, substitute=false
+)
+    logger.levels = levels
+    setlevel!(logger, level; recursive=recursive)
+    handler = DefaultHandler(
+        stdout,
+        DefaultFormatter(fmt), Dict{Symbol, Any}(:is_colorized => colorized)
+    )
+    logger.handlers["console"] = handler
+    register(logger)
+
+    substitute && substitute!()
+
+    return logger
+end
+
+"""
+    reset!()
+
+Removes all registered loggers and reinitializes the root logger
+without any handlers.
+"""
+function reset!()
+    empty!(_loggers)
+    register(Logger("root"))
+    nothing
+end

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -134,29 +134,27 @@ Register an existing logger with Memento.
 register(logger::Logger) = _loggers[logger.name] = logger
 
 """
-    getparent(name::AbstractString) -> Logger
+    getpath(logger::Logger) -> Vector{Logger}
 
-Takes a string representing the name of a logger and returns
-its parent. If the logger name has no parent then the root logger is returned.
-Parent loggers are extracted assuming a naming convention of "foo.bar.baz", where
-"foo.bar.baz" is the child of "foo.bar" which is the child of "foo".
-
-# Arguments
-* `name::AbstractString`: the name of the logger.
-
-# Returns
-* `Logger`: the parent logger.
+Returns the path of logger from the root logger.
 """
-function getparent(name)
-    tokenized = split(name, '.')
+function getpath(logger::Logger)
+    isroot(logger) && return [logger]
 
-    if length(tokenized) == 1
-        return getlogger("root")
-    elseif length(tokenized) == 2
-        return getlogger(tokenized[1])
-    else
-        return getlogger(join(tokenized[1:end-1], '.'))
+    tokenized = split(logger.name, '.')
+    results = Vector{Logger}(undef, length(tokenized) + 1)
+
+    # Set the root logger as the first element
+    results[1] = getlogger("root")
+    # Set our input logger as the last logger in case the 
+    # input logger isn't registered.
+    results[end] = logger           
+
+    for i in 1:length(tokenized)-1
+        results[i+1] = getlogger(join(tokenized[1:i], '.'))
     end
+
+    return results
 end
 
 """
@@ -211,7 +209,6 @@ function getlogger(name="root")
     logger_name = name == "" ? "root" : name
 
     if !(haskey(_loggers, logger_name))
-        parent = getparent(logger_name)
         register(Logger(logger_name))
     end
 
@@ -333,15 +330,17 @@ method with a `@sync` in order to synchronize all handler tasks.
 * `args::Dict`: a dict of msg fields and values that should be passed to `logger.record`.
 """
 function log(logger::Logger, rec::Record)
-    # If none of the `Filter`s return false we're good to log our record.
-    if all(f -> f(rec), getfilters(logger))
-        for (name, handler) in logger.handlers
+    @sync for l in reverse!(getpath(logger))
+        # If none of the `Filter`s return false we're good to log our record.
+        !all(f -> f(rec), getfilters(l)) && break
+
+        # Log to all of our handlers
+        for (name, handler) in l.handlers
             @async log(handler, rec)
         end
 
-        if !isroot(logger) && logger.propagate
-            log(getparent(logger.name), rec)
-        end
+        # Break if this is the root logger or it's non-propagating
+        isroot(l) || !l.propagate && break
     end
 end
 
@@ -363,7 +362,7 @@ with the created `Dict`).
 """
 function log(logger::Logger, level::AbstractString, msg::AbstractString)
     rec = logger.record(logger.name, level, logger.levels[level], msg)
-    @sync log(logger, rec)
+    log(logger, rec)
 end
 
 """
@@ -383,7 +382,7 @@ be a function that returns the log message string.
 """
 function log(msg::Function, logger::Logger, level::AbstractString)
     rec = logger.record(logger.name, level, logger.levels[level], msg)
-    @sync log(logger, rec)
+    log(logger, rec)
 end
 
 #=

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -134,56 +134,6 @@ Register an existing logger with Memento.
 register(logger::Logger) = _loggers[logger.name] = logger
 
 """
-    config!([logger], level; fmt::AbstractString, levels::Dict{AbstractString, Int}, colorized::Bool) -> Logger
-
-Sets the `Memento._log_levels`, creates a default root logger with a `DefaultHandler`
-that prints to stdout.
-
-# Arguments
-* 'logger::Union{Logger, AbstractString}`: The logger to configure (optional)
-* `level::AbstractString`: the minimum logging level to log message to the root logger (required).
-* `fmt::AbstractString`: a format string to pass to the `DefaultFormatter` which describes
-    how to log messages (defaults to `Memento.DEFAULT_FMT_STRING`)
-* `levels`: the default logging levels to use (defaults to `Memento._log_levels`).
-* `colorized`: whether or not the message to stdout should be colorized.
-
-# Returns
-* `Logger`: the root logger.
-"""
-config!(level::AbstractString; kwargs...) = config!(Logger("root"), level; kwargs...)
-
-function config!(logger::AbstractString, level::AbstractString; kwargs...)
-    config!(Logger(logger), level; kwargs...)
-end
-
-function config!(
-    logger::Logger, level::AbstractString;
-    fmt::AbstractString=DEFAULT_FMT_STRING, levels=_log_levels, colorized=true, recursive=false
-)
-    logger.levels = levels
-    setlevel!(logger, level; recursive=recursive)
-    handler = DefaultHandler(
-        stdout,
-        DefaultFormatter(fmt), Dict{Symbol, Any}(:is_colorized => colorized)
-    )
-    logger.handlers["console"] = handler
-    register(logger)
-    return logger
-end
-
-"""
-    reset!()
-
-Removes all registered loggers and reinitializes the root logger
-without any handlers.
-"""
-function reset!()
-    empty!(_loggers)
-    register(Logger("root"))
-    nothing
-end
-
-"""
     getparent(name::AbstractString) -> Logger
 
 Takes a string representing the name of a logger and returns

--- a/src/stdlib.jl
+++ b/src/stdlib.jl
@@ -1,0 +1,21 @@
+import Base.CoreLogging: 
+    AbstractLogger,
+    handle_message,
+    min_enabled_level,
+    shouldlog,
+    global_logger,
+    Debug
+
+struct CoreLogger <: AbstractLogger
+end
+
+min_enabled_level(logger::CoreLogger) = Debug
+shouldlog(logger::CoreLogger, arags...) = true
+
+function handle_message(::CoreLogger, cl_level, msg, mod, group, id, filepath, line; kwargs...)
+    logger = getlogger(mod)
+    level = lowercase(string(cl_level))
+    @sync log(logger, logger.record(logger.name, level, logger.levels[level], msg))
+end
+
+setglobal!() = global_logger(CoreLogger())

--- a/src/stdlib.jl
+++ b/src/stdlib.jl
@@ -1,21 +1,34 @@
-import Base.CoreLogging: 
-    AbstractLogger,
-    handle_message,
-    min_enabled_level,
-    shouldlog,
-    global_logger,
-    Debug
+if VERSION > v"0.7.0-DEV.2980"
+    import Base.CoreLogging:
+        AbstractLogger,
+        handle_message,
+        min_enabled_level,
+        shouldlog,
+        global_logger,
+        Debug
 
-struct CoreLogger <: AbstractLogger
+    const LEVEL_MAP = Dict{AbstractString}
+    struct CoreLogger <: AbstractLogger
+    end
+
+    min_enabled_level(logger::CoreLogger) = Debug
+    shouldlog(logger::CoreLogger, arags...) = true
+
+    function handle_message(::CoreLogger, cl_level, msg, mod, group, id, filepath, line; kwargs...)
+        logger = getlogger(mod)
+        level = lowercase(string(cl_level))
+        @sync log(logger, logger.record(logger.name, level, logger.levels[level], msg))
+    end
+
+    function substitute!()
+        global_logger(CoreLogger())
+        notice(getlogger(@__MODULE__), "Substituting global logging with Memento")
+    end
+else
+    function substitute!()
+        warn(
+            getlogger(@__MODULE__),
+            "Global logging substitution is not support for julia $VERSION"
+        )
+    end
 end
-
-min_enabled_level(logger::CoreLogger) = Debug
-shouldlog(logger::CoreLogger, arags...) = true
-
-function handle_message(::CoreLogger, cl_level, msg, mod, group, id, filepath, line; kwargs...)
-    logger = getlogger(mod)
-    level = lowercase(string(cl_level))
-    @sync log(logger, logger.record(logger.name, level, logger.levels[level], msg))
-end
-
-setglobal!() = global_logger(CoreLogger())

--- a/src/stdlib.jl
+++ b/src/stdlib.jl
@@ -17,7 +17,7 @@ if VERSION > v"0.7.0-DEV.2980"
     function handle_message(::CoreLogger, cl_level, msg, mod, group, id, filepath, line; kwargs...)
         logger = getlogger(mod)
         level = lowercase(string(cl_level))
-        @sync log(logger, logger.record(logger.name, level, logger.levels[level], msg))
+        log(logger, logger.record(logger.name, level, logger.levels[level], msg))
     end
 
     function substitute!()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,7 @@ files = [
     "io.jl",
     "concurrency.jl",
     "test.jl",
+    "stdlib.jl",
     "ext/json.jl",
 ]
 

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -1,0 +1,26 @@
+@testset "stdlib" begin
+    @testset "$VERSION" begin
+        if VERSION > v"0.7.0-DEV.2980"
+            orig_logger = Base.CoreLogging.global_logger()
+
+            try
+                logger = getlogger("Memento")
+                @test_log(
+                    logger,
+                    "notice",
+                    "Substituting global logging",
+                    Memento.config!("info"; substitute=true)
+                )
+            finally
+                Base.CoreLogging.global_logger(orig_logger)
+            end
+        else
+            logger = getlogger("Memento")
+            @test_warn(
+                logger,
+                "Global logging substitution is not support for julia",
+                Memento.config!("info"; substitute=true)
+            )
+        end
+    end
+end


### PR DESCRIPTION
Initial attempt to get stdlib logging working.

Example)
```julia
julia> using Memento; getlogger(@__MODULE__); Memento.config!("info"; recursive=true); Memento.setglobal!()
Logging.ConsoleLogger(Base.TTY(RawFD(0x0000000f) open, 0 bytes waiting), Info, Logging.default_metafmt, true, 0, Dict{Any,Int64}(Pair{Any,Int64}((Base.InterpreterIP(CodeInfo(:(begin
      Core.SSAValue(0) = current_module()
      return Core.SSAValue(0)
  end)), 0x0000000000000000), :current_module), 0)))

julia> @info "Foo"
WARNING: importing deprecated binding Base.myid into Memento.
WARNING: Base.myid is deprecated: it has been moved to the standard library package `Distributed`.
Add `using Distributed` to your imports.
  likely near no file:310
WARNING: Base.myid is deprecated: it has been moved to the standard library package `Distributed`.
Add `using Distributed` to your imports.
  likely near no file:310
WARNING: Base.myid is deprecated: it has been moved to the standard library package `Distributed`.
Add `using Distributed` to your imports.
  likely near no file:310
[info | Main]: Foo
```

I'll note that using Memento has slightly worse performance than base when we're actually writing messages. The bigger issue is that no-op conditions are slower if we route everything to Memento.
```
# Base: `@info`

julia> @benchmark @info "Foo"
...
BenchmarkTools.Trial: 
  memory estimate:  3.50 KiB
  allocs estimate:  87
  --------------
  minimum time:     37.108 μs (0.00% GC)
  median time:      50.513 μs (0.00% GC)
  mean time:        88.835 μs (2.38% GC)
  maximum time:     22.891 ms (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1

# Memento: `@info`

julia> @benchmark @info "Foo"
...
BenchmarkTools.Trial: 
  memory estimate:  5.33 KiB
  allocs estimate:  111
  --------------
  minimum time:     61.727 μs (0.00% GC)
  median time:      70.142 μs (0.00% GC)
  mean time:        78.761 μs (9.54% GC)
  maximum time:     58.598 ms (99.65% GC)
  --------------
  samples:          10000
  evals/sample:     1

# Base: `@debug`

julia> @benchmark @debug "Foo"
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     122.010 ns (0.00% GC)
  median time:      124.102 ns (0.00% GC)
  mean time:        127.923 ns (0.00% GC)
  maximum time:     179.063 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     903


# Memento: `@debug`

julia> @benchmark @debug "Foo"
BenchmarkTools.Trial: 
  memory estimate:  1.58 KiB
  allocs estimate:  45
  --------------
  minimum time:     17.152 μs (0.00% GC)
  median time:      17.795 μs (0.00% GC)
  mean time:        18.505 μs (0.00% GC)
  maximum time:     87.248 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1
```

The slower no-op performance is an accepted compromise with Memento's design (for tracing code [Trace.jl](https://github.com/invenia/Trace.jl) would be a better choice). A middle ground may be to not route debug messages to Memento by default. 