### PR TITLE
Set default log level to info

### DIFF
--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -24,7 +24,7 @@ export debug, notice, error, critical, alert, emergency,
        DefaultFormatter, DictFormatter, DefaultHandler, FileRoller
 
 
-const DEFAULT_LOG_LEVEL = "warn"
+const DEFAULT_LOG_LEVEL = "info"
 
 const _log_levels = Dict{AbstractString, Int}(
     "not_set" => 0,

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -150,7 +150,10 @@ that prints to stdout.
 # Returns
 * `Logger`: the root logger.
 """
-config!(level::AbstractString; kwargs...) = config!(Logger("root"), level; kwargs...)
+function config!(level::AbstractString; kwargs...)
+    DEFAULT_LOG_LEVEL = level
+    config!(Logger("root"), level; kwargs...)
+end
 
 function config!(logger::AbstractString, level::AbstractString; kwargs...)
     config!(Logger(logger), level; kwargs...)

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -150,10 +150,7 @@ that prints to stdout.
 # Returns
 * `Logger`: the root logger.
 """
-function config!(level::AbstractString; kwargs...)
-    DEFAULT_LOG_LEVEL = level
-    config!(Logger("root"), level; kwargs...)
-end
+config!(level::AbstractString; kwargs...) = config!(Logger("root"), level; kwargs...)
 
 function config!(logger::AbstractString, level::AbstractString; kwargs...)
     config!(Logger(logger), level; kwargs...)

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -153,11 +153,11 @@
         foo_children = Memento.getchildren("foo")
         a_children = Memento.getchildren("a")
 
-        @test all(==("warn"), getlevel.(foo_children))
-        setlevel!(getlogger("foo"), "info"; recursive=true)
-
         @test all(==("info"), getlevel.(foo_children))
-        @test all(==("warn"), getlevel.(a_children))
+        setlevel!(getlogger("foo"), "debug"; recursive=true)
+
+        @test all(==("debug"), getlevel.(foo_children))
+        @test all(==("info"), getlevel.(a_children))
 
         setlevel!(getlogger("foo"), "notice"; recursive=true) do
             info(getlogger("foo"), "I shouldn't be getting printed.")
@@ -165,8 +165,8 @@
 
         # Check that our child logging levels remain the same after
         # the above call.
-        @test all(==("info"), getlevel.(foo_children))
-        @test all(==("warn"), getlevel.(a_children))
+        @test all(==("debug"), getlevel.(foo_children))
+        @test all(==("info"), getlevel.(a_children))
     end
 
     @testset "Memento.config" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,7 +55,7 @@ end
 
         for l in (foo, bar, baz, car)
             @test isset(l)
-            @test getlevel(l) == "warn"
+            @test getlevel(l) == "info"
             @test length(gethandlers(l)) == 0
         end
 
@@ -70,35 +70,35 @@ end
         result = String(take!(root_io))
         @test occursin(expected, result)
 
-        msg = "This should not log because info messages don't have high enough importance."
-        info(bar, msg)
+        msg = "This should not log because debug messages don't have high enough importance."
+        debug(bar, msg)
         result = String(take!(root_io))
         @test result == ""
 
-        setlevel!(getlogger(), "info")
+        setlevel!(getlogger(), "debug")
         msg = "This should log to because we've set the root logger to info"
-        info(getlogger(), msg)
+        debug(getlogger(), msg)
         result = String(take!(root_io))
-        expected = "root - info: $msg"
+        expected = "root - debug: $msg"
         @test occursin(expected, result)
 
         msg = "This should not log because `bar` is set too low"
-        info(bar, msg)
+        debug(bar, msg)
         result = String(take!(root_io))
         @test result == ""
 
-        setlevel!(bar, "info")
+        setlevel!(bar, "debug")
         msg = "This should still not log because `foo` is set too low"
-        info(bar, msg)
+        debug(bar, msg)
         result = String(take!(root_io))
         @test result == ""
 
         # Now if we have the chain of root, foo and bar all set to info then the log record
         # will propagate up from the bar logger to be written to the buffer by the root loggers handler.
-        setlevel!(foo, "info")
+        setlevel!(foo, "debug")
         msg = "Now this should log because `bar`, `foo` and the root logger are all set appropriately."
-        info(bar, msg)
-        expected = "Foo.Bar - info: $msg"
+        debug(bar, msg)
+        expected = "Foo.Bar - debug: $msg"
         result = String(take!(root_io))
         @test occursin(expected, result)
 
@@ -106,6 +106,9 @@ end
         # propagate to the root logger.
         setlevel!(baz, "debug")
         push!(baz, DefaultHandler(baz_io, DefaultFormatter("{name} - {level}: {msg}")))
+
+        # Reset the parent loggers
+        setlevel!.((foo, bar), "info")
 
         msg = "This should log to `baz_io`, but not `root_io`"
         debug(baz, msg)


### PR DESCRIPTION
- Sets the default log level to info
- `config!` now modifies the default constant if called without a logger

Closes #70 