### PR TITLE
More 0.7 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ notifications:
   email: false
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("Memento")'
+  - julia ./.travis/build.jl
   - ./.travis/test.sh
 after_success:
   - julia -e 'cd(Pkg.dir("Memento")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/.travis/build.jl
+++ b/.travis/build.jl
@@ -1,0 +1,8 @@
+if VERSION > v"0.7.0-DEV.3656"
+    using OldPkg
+    OldPkg.clone(pwd())
+    OldPkg.build("Memento")
+else
+    Pkg.clone(pwd())
+    Pkg.build("Memento")
+end

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,12 @@
+desc = "A flexible logging library for Julia"
+keywords = ["logging"]
+license = "MIT"
+name = "Memento"
+uuid = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
+version = "v0.6.0"
+
+[deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Nullables = "4d1e1d77-625e-5b40-9113-a560ec7a8ecd"
+Syslogs = "cea106d9-e007-5e6c-ad93-58fe2094e9c4"

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -386,7 +386,8 @@ function log(logger::Logger, rec::Record)
     # If none of the `Filter`s return false we're good to log our record.
     if all(f -> f(rec), getfilters(logger))
         for (name, handler) in logger.handlers
-            @async log(handler, rec)
+            # @async log(handler, rec)
+            log(handler, rec)
         end
 
         if !isroot(logger) && logger.propagate


### PR DESCRIPTION
- Add a Project.toml file give the hard switch to Pkg3 in nightly
- Don't use `@async` when logging to handlers because that appears to be causing tests to fail now.