### PR TITLE
Recommend using `@__MODULE__`

### DIFF
--- a/docs/src/faq/pkg-usage.md
+++ b/docs/src/faq/pkg-usage.md
@@ -8,13 +8,16 @@ __precompile__() # this module is safe to precompile
 module MyModule
 
 using Memento
+using Compat: @__MODULE__  # requires a minimum of Compat 0.26. Not required on Julia 0.7
 
 # Create our module level logger (this will get precompiled)
-const LOGGER = get_logger(current_module())   # or `get_logger(@__MODULE__)` on 0.7
+const LOGGER = get_logger(@__MODULE__)
 
 # Register the module level logger at runtime so that folks can access the logger via `get_logger(MyModule)`
 # NOTE: If this line is not included then the precompiled `MyModule.LOGGER` won't be registered at runtime.
-__init__() = Memento.register(LOGGER)
+function __init__()
+    Memento.register(LOGGER)
+end
 
 end
 ```

--- a/docs/src/faq/pkg-usage.md
+++ b/docs/src/faq/pkg-usage.md
@@ -7,7 +7,7 @@ Specifically, it is important to note that if you want folks be able to configur
 __precompile__() # this module is safe to precompile
 module MyModule
 
-using Memento
+using Memento  # requires a minimum of Memento 0.3.2
 using Compat: @__MODULE__  # requires a minimum of Compat 0.26. Not required on Julia 0.7
 
 # Create our module level logger (this will get precompiled)

--- a/docs/src/faq/pkg-usage.md
+++ b/docs/src/faq/pkg-usage.md
@@ -7,11 +7,11 @@ Specifically, it is important to note that if you want folks be able to configur
 __precompile__() # this module is safe to precompile
 module MyModule
 
-using Memento  # requires a minimum of Memento 0.3.2
+using Memento  # requires a minimum of Memento 0.5
 using Compat: @__MODULE__  # requires a minimum of Compat 0.26. Not required on Julia 0.7
 
 # Create our module level logger (this will get precompiled)
-const LOGGER = get_logger(@__MODULE__)
+const LOGGER = getlogger(@__MODULE__)
 
 # Register the module level logger at runtime so that folks can access the logger via `get_logger(MyModule)`
 # NOTE: If this line is not included then the precompiled `MyModule.LOGGER` won't be registered at runtime.


### PR DESCRIPTION
Since Julia 0.7 is right around the corner it seems appropriate to use the Julia 0.7 syntax in the documentation and use Compat on older versions.