### PR TITLE
Store dates in UTC but print them in local time

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ Compat 0.65.0
 Syslogs 0.0.1
 JSON 0.16.1
 Nullables 0.0.3
+TimeZones 0.7

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -12,6 +12,7 @@ using Compat.Distributed
 import Syslogs
 import JSON
 using Nullables
+using TimeZones
 
 import Base: show, info, warn, error, log
 

--- a/src/records.jl
+++ b/src/records.jl
@@ -127,7 +127,7 @@ NOTE: if you'd like more logging attributes you can:
 2. make a custom `Record` type.
 
 # Fields
-* `date::Attribute{DateTime}`: timestamp of log event
+* `date::Attribute{ZonedDateTime}`: timestamp of log event
 * `level::Attribute{AbstractString}`: log level
 * `levelnum::Attribute{Int}`: integer value for log level
 * `msg::Attribute{AbstractString}`: the log message itself
@@ -158,11 +158,10 @@ Takes a few initial log record arguments and creates a `DefaultRecord`.
 * `msg::AbstractString`: the message being logged.
 """
 function DefaultRecord(name::AbstractString, level::AbstractString, levelnum::Int, msg)
-    time = Dates.now()
     trace = Attribute{StackTrace}(get_trace)
 
     DefaultRecord(
-        Attribute{DateTime}(() -> round(time, Dates.Second)),
+        Attribute{ZonedDateTime}(() -> Dates.now(tz"UTC")),
         Attribute(level),
         Attribute(levelnum),
         Attribute{AbstractString}(msg),

--- a/test/formatters.jl
+++ b/test/formatters.jl
@@ -23,6 +23,34 @@
 
         nl_result = Memento.format(fmt, no_lookup)
         @test startswith(nl_result, "<nothing>")
+
+        @testset "Date handling" begin
+            withenv("TZ" => "UTC+02") do
+                local_date = ZonedDateTime(2012, 1, 1, 3, 1, 1, 123, localzone())
+                local_datestr = "2012-01-01 03:01:01"
+                utc_date = astimezone(local_date, tz"UTC")
+                utc_datestr = Dates.format(utc_date, "yyyy-mm-dd HH:MM:SS")
+
+                fmt = DefaultFormatter("{date}")
+                tz_rec = SimpleRecord("info", "blah", local_date)
+                @test Memento.format(fmt, tz_rec) == local_datestr
+
+                utc_rec = SimpleRecord("info", "blah", utc_date)
+                @test Memento.format(fmt, utc_rec) == local_datestr
+
+                utc_fmt = DefaultFormatter("{date}", tz"UTC")
+                @test Memento.format(utc_fmt, tz_rec) == utc_datestr
+                @test Memento.format(utc_fmt, utc_rec) == utc_datestr
+
+                date = DateTime(2012, 1, 1, 3, 1, 1)
+                notz_rec = SimpleRecord("info", "blah", date)
+                @test Memento.format(fmt, notz_rec) == local_datestr
+
+                ts = 1531949014
+                ts_rec = SimpleRecord("info", "blah", ts)
+                @test Memento.format(fmt, ts_rec) == string(ts)
+            end
+        end
     end
 
     @testset "DictFormatter" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using Syslogs
 using Memento
 using Memento.Test
 using TestSetExtensions
+using TimeZones
 
 import Compat.Dates
 import Compat.Sys
@@ -33,10 +34,13 @@ struct TestError <: Exception
 end
 
 # for records.jl
-struct SimpleRecord <: Record
+struct SimpleRecord{T} <: Record
     level::String
     msg::String
+    date::T
 end
+
+SimpleRecord(level, msg) = SimpleRecord(level, msg, Dates.now(tz"UTC"))
 
 struct ConstRecord <: AttributeRecord
 end


### PR DESCRIPTION
* Adds TimeZones as a dependency
* Stores dates in DefaultRecords as UTC
* Adds an output_tz field to DefaultFormatter which defaults to localzone
* Adds special path to handle formatting dates which prints ZonedDateTimes in local time and DateTimes as they are
* Modifies date printing format to use space instead of "T" and print only second-level precision