### PR TITLE
Updates for Julia 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ os:
   - linux
 julia:
   - 0.6
+  - 0.7
+  - 1.0
   - nightly
 env:
   - TEST_TYPE=basic
@@ -25,9 +27,20 @@ matrix:
 notifications:
   email: false
 script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("Memento")'
   - ./.travis/test.sh
 after_success:
-  - julia -e 'cd(Pkg.dir("Memento")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
-  - julia -e 'cd(Pkg.dir("Memento")); Pkg.add("Documenter"); include(joinpath("docs", "make.jl"))'
+  - |
+      julia -e '
+        VERSION >= v"0.7.0-DEV.3656" && using Pkg
+        VERSION >= v"0.7.0-DEV.5183" || cd(Pkg.dir("Memento"))
+        Pkg.add("Coverage")
+        using Coverage
+        Codecov.submit(Codecov.process_folder())
+      '
+  - |
+      julia -e '
+        VERSION >= v"0.7.0-DEV.3656" && using Pkg
+        VERSION >= v"0.7.0-DEV.5183" || cd(Pkg.dir("Memento"))
+        Pkg.add("Documenter")
+        include(joinpath("docs", "make.jl"))
+      '

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ matrix:
   allow_failures:
     - julia: nightly
     - env: TEST_TYPE=bench
+    - julia: 0.7
+      env: TEST_TYPE=userimage
+    - julia: 1.0
+      env: TEST_TYPE=userimage
   include:
     - if: branch = master
       julia: 0.6

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -2,20 +2,62 @@
 
 set -ev
 
+# Set up the build environment across Julia versions
+# This portion is the same as the default Travis test script:
+# https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/script/julia.rb
+if [[ -a .git/shallow ]]; then
+    git fetch --unshallow
+fi
+if [[ -f Project.toml || -f JuliaProject.toml ]]; then
+    # Run build step
+    julia --color=yes -e '
+        if VERSION < v"0.7.0-DEV.5183"
+            Pkg.clone(pwd())
+            Pkg.build("Memento")
+        else
+            using Pkg
+            Pkg.build()
+        end
+    '
+    # Set up test step (run below)
+    TESTCMD='
+        if VERSION < v"0.7.0-DEV.5183"
+            Pkg.test("Memento", coverage=true)
+        else
+            using Pkg
+            Pkg.test(coverage=true)
+        end
+    '
+else
+    # Run build step
+    julia --color=yes -e '
+        VERSION >= v"0.7.0-DEV.5183" && using Pkg
+        Pkg.clone(pwd())
+        Pkg.build("Memento")
+    '
+    # Set up test step (run below)
+    TESTCMD='
+        VERSION >= v"0.7.0-DEV.5183" && using Pkg
+        Pkg.test("Memento", coverage=true)
+    '
+fi
+
 if [[ "$TEST_TYPE" == "basic" ]]; then
     # Run parallel tests
-    julia -e 'Pkg.test("Memento"; coverage=true)'
+    julia --color=yes --check-bounds=yes -e "$TESTCMD"
 elif [[ "$TEST_TYPE" == "bench" ]]; then
     # Run benchmark tests
     export MEMENTO_BENCHMARK="true"
     export MEMENTO_CURR_COMMIT="HEAD"
     export MEMENTO_BASE_COMMIT="origin/master"
-    julia -e 'Pkg.test("Memento"; coverage=true)'
+    julia --color=yes --check-bounds=yes -e "$TESTCMD"
 elif [[ "$TEST_TYPE" == "userimage" ]]; then
     # Create a user image which includes Memento to make sure that _loggers is assigned at compile-time
     # See: https://github.com/invenia/Memento.jl/pull/21
-    julia -e '
-        LIB_PATH = abspath(Base.JULIA_HOME, Base.LIBDIR)
+    julia --color=yes -e '
+        VERSION >= v"0.7.0-DEV.3382" && using Libdl
+        BINDIR = VERSION < v"0.7.0-DEV.3073" ? Base.JULIA_HOME : Sys.BINDIR
+        LIB_PATH = abspath(BINDIR, Base.LIBDIR)
         sysimg_lib = joinpath(LIB_PATH, "julia", "sys.$(Libdl.dlext)")
         userimg_o = "userimg.o"
         userimg_lib = "userimg.$(Libdl.dlext)"

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -61,7 +61,10 @@ elif [[ "$TEST_TYPE" == "userimage" ]]; then
         sysimg_lib = joinpath(LIB_PATH, "julia", "sys.$(Libdl.dlext)")
         userimg_o = "userimg.o"
         userimg_lib = "userimg.$(Libdl.dlext)"
-        run(`$(Base.julia_cmd()) --output-o $userimg_o --sysimage $sysimg_lib --startup-file=no -e "using Memento; logger = getlogger(\"Test\")"`)
+        code = "Base.reinit_stdio(); using Memento; "
+        VERSION >= v"0.7.0-DEV.2005" && (code *= "using Test; ")
+        code *= "logger = getlogger(\"Test\")"
+        run(`$(Base.julia_cmd()) --output-o $userimg_o --sysimage $sysimg_lib --startup-file=no -e "$code"`)
         run(`cc -shared -o $userimg_lib $userimg_o -ljulia -L$LIB_PATH`)
     '
 fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,19 +1,21 @@
 environment:
   matrix:
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.6
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
 
 matrix:
   allow_failures:
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: nightly
 
 branches:
   only:
     - master
-    - windows
     - /release-.*/
 
 notifications:
@@ -23,27 +25,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# If there's a newer build queued for the same PR, cancel this one
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-        throw "There are newer queued builds for this pull request, failing early." }
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia --startup-file=yes --compilecache=no -e "versioninfo();
-      Pkg.clone(pwd(), \"Memento\"); Pkg.build(\"Memento\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"Memento\")"
-  - C:\projects\julia\bin\julia --compilecache=no -e "Pkg.test(\"Memento\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
 # on_success:
-#   - C:\projects\julia\bin\julia -e "cd(Pkg.dir(\"Memento\")); Pkg.add(\"Coverage\"); using Coverage; Codecov.submit(Codecov.process_folder())'
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -14,7 +14,13 @@ import JSON
 using Nullables
 using TimeZones
 
-import Base: show, info, warn, error, log
+import Base: show, error, log
+
+if isdefined(Base, :info) # Turned into macros in 0.7
+    import Base: info, warn
+else
+    export info, warn
+end
 
 export debug, notice, error, critical, alert, emergency,
        isset, isroot, ispropagating, setpropagating!,

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -3,4 +3,3 @@
 Syslogs 0.1.1
 JSON 0.16.1
 Suppressor 0.0.5
-TestSetExtensions

--- a/test/ext/syslogs.jl
+++ b/test/ext/syslogs.jl
@@ -5,7 +5,7 @@ function udp_srv(port::Int)
     sock = UDPSocket()
     bind(sock, ip"127.0.0.1", port)
 
-    @schedule begin
+    @async begin
         put!(r, String(recv(sock)))
         close(sock)
     end

--- a/test/handlers.jl
+++ b/test/handlers.jl
@@ -106,7 +106,7 @@
 
         @testset "Sample Usage w/ File" begin
             filename = tempname()
-            info("Path to log file: $filename")
+            @info("Path to log file: $filename")
 
             handler = DefaultHandler(filename)
 
@@ -158,7 +158,7 @@
 
         @testset "Filename Construction" begin
             filename = tempname()
-            info("Path to log file: $filename")
+            @info("Path to log file: $filename")
             handler1 = DefaultHandler(filename)
 
             @test handler1.fmt.fmt_str == Memento.DEFAULT_FMT_STRING

--- a/test/io.jl
+++ b/test/io.jl
@@ -9,7 +9,7 @@
             "fubar" => 50
         )
         roller_prefix = tempname()
-        info("Path to roller_prefix: $roller_prefix")
+        @info("Path to roller_prefix: $roller_prefix")
         handler = DefaultHandler(FileRoller(roller_prefix; max_sz=1024))
 
         logger = Logger(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,9 +76,13 @@ end
 
 _props(cr::ConstRecord) = (:level => cr[:level], :msg => cr[:msg])
 
-Base.start(cr::ConstRecord) = start(_props(cr))
-Base.next(cr::ConstRecord, state) = next(_props(cr), state)
-Base.done(cr::ConstRecord, state) = done(_props(cr), state)
+if isdefined(Base, :iterate)
+    Base.iterate(cr::ConstRecord, state...) = iterate(_props(cr), state...)
+else
+    Base.start(cr::ConstRecord) = start(_props(cr))
+    Base.next(cr::ConstRecord, state) = next(_props(cr), state)
+    Base.done(cr::ConstRecord, state) = done(_props(cr), state)
+end
 
 @testset ExtendedTestSet "Memento" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,8 @@ using TimeZones
 import Compat.Dates
 import Compat.Sys
 
+using Compat: @info
+
 files = [
     "records.jl",
     "formatters.jl",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,6 @@ using JSON
 using Syslogs
 using Memento
 using Memento.Test
-using TestSetExtensions
 using TimeZones
 
 import Compat.Dates
@@ -84,7 +83,7 @@ else
     Base.done(cr::ConstRecord, state) = done(_props(cr), state)
 end
 
-@testset ExtendedTestSet "Memento" begin
+@testset "Memento" begin
 
 @testset "Logging" begin
     @testset "Sample Usage" begin


### PR DESCRIPTION
Now `info` and `warn` are only imported and extended from Base when they're defined in Base. Travis and AppVeyor have been updated to handle versions 0.6 through 1.0.

Supersedes #100.