### PR TITLE
Make Test a dependency and rename Memento.Test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 Syslogs = "cea106d9-e007-5e6c-ad93-58fe2094e9c4"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
@@ -18,7 +19,6 @@ julia = "0.7, 1.0"
 
 [extras]
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Suppressor", "Test"]
+test = ["Suppressor"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter
 using Memento
 
 makedocs(
-    modules=[Memento, Memento.Test],
+    modules=[Memento, Memento.TestUtils],
     format=Documenter.HTML(prettyurls=(get(ENV, "CI", nothing) == "true")),
     repo="https://github.com/invenia/Memento.jl/blob/{commit}{path}#L{line}",
     sitename="Memento.jl",

--- a/docs/src/api/public.md
+++ b/docs/src/api/public.md
@@ -45,10 +45,10 @@ Private = false
 Pages = ["io.jl"]
 ```
 
-## Memento.Test
+## Memento.TestUtils
 
 ```@docs
-Memento.Test.@test_log
-Memento.Test.@test_warn
-Memento.Test.@test_throws
+Memento.TestUtils.@test_log
+Memento.TestUtils.@test_warn
+Memento.TestUtils.@test_throws
 ```

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,1 +1,3 @@
 @deprecate config(args...; kwargs...) config!(args...; kwargs...)
+
+Base.@deprecate_binding Test Memento.TestUtils false

--- a/src/memento_test.jl
+++ b/src/memento_test.jl
@@ -1,4 +1,4 @@
-module Test
+module TestUtils
 
 using ..Memento
 using Test
@@ -44,7 +44,7 @@ end
 """
     @test_warn(logger, msg, expr)
 
-Convenience macro that calls `Memento.Test.@test_log(logger, "warn", msg, expr)`.
+Convenience macro that calls `Memento.TestUtils.@test_log(logger, "warn", msg, expr)`.
 """
 macro test_warn(logger, msg, expr)
     quote

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using Suppressor
 using JSON
 using Syslogs
 using Memento
-using Memento.Test
+using Memento.TestUtils
 using TimeZones
 using Dates
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -1,4 +1,4 @@
-@testset "Memento.Test" begin
+@testset "Memento.TestUtils" begin
     @testset "@test_log" begin
         logger = getlogger("test_log")
         msg = "Hello!"


### PR DESCRIPTION
The first commit here moves Test from a test-only dependency to a direct dependency. This is required because its functionality is extended in the Test submodule of Memento.

The second commit renames the Test submodule to TestUtils, thereby fixing #111.