### PR TITLE
Change sentinel for test_warn error message

### DIFF
--- a/src/memento_test.jl
+++ b/src/memento_test.jl
@@ -7,6 +7,8 @@ import Test: @test_warn, @test_throws
 
 export @test_log
 
+const EMPTY_MATCH = nothing
+
 # These function are just a copy of `ismatch_warn` on 0.6 or `contains_warn` on 0.7`.
 # contains_msg(output, s) = contains_warn(output, s)
 occursin_msg(s::AbstractString, output) = occursin(s, output)
@@ -75,7 +77,7 @@ end
 
 function TestHandler(level, msg)
     TestHandler{DefaultFormatter, IOBuffer}(
-        String(level), msg, ("", "")
+        String(level), msg, (EMPTY_MATCH, EMPTY_MATCH)
     )
 end
 


### PR DESCRIPTION
Closes #106 

The error message printed would be:

```julia
julia> @test_warn(TESTLOG, "ModA warning 1", ModA.danger())
Test Failed at /Users/nicoleepp/.julia/dev/Memento/src/memento_test.jl:34
  Expression: handler.found[1] == $(Expr(:escape, "warn"))
   Evaluated: nothing == "warn"
ERROR: There was an error during testing
```

Which to me is clearer than "" since the pattern matching didn't find anything. Open to better sentinel suggestions though.