### PR TITLE
Switch to `getproperty` for AttributeRecord

### DIFF
--- a/docs/src/man/records.md
+++ b/docs/src/man/records.md
@@ -12,7 +12,7 @@ An [`AttributeRecord`](@ref Memento.AttributeRecord) is an abstract subtype of [
 Fields are stored as [`Attribute`](@ref Memento.Attribute)s, which will evaluate a function and cache the result the first time it is read.
 
 By default, any subtypes of [`AttributeRecord`](@ref Memento.AttributeRecord) will expect its fields to be [`Attribute`](@ref Memento.Attribute)s.
-Non-standard subtypes of [`AttributeRecord`](@ref Memento.AttributeRecord) should implement `Memento.getattribute(::MyRecord, ::Symbol)` and key-value pair iteration, where the values have been extracted from [`Attribute`](@ref Memento.Attribute)s using [`get`](@ref).
+Non-standard subtypes of [`AttributeRecord`](@ref Memento.AttributeRecord) should implement `Base.getproperty(::MyRecord, ::Symbol)` and key-value pair iteration, where the values have been extracted from [`Attribute`](@ref Memento.Attribute)s using [`get`](@ref).
 
 ## Custom Record Types
 

--- a/src/records.jl
+++ b/src/records.jl
@@ -81,7 +81,7 @@ instead of `getindex`.
 """
 abstract type AttributeRecord <: Record end
 
-Base.getindex(rec::Record, attr::Symbol) = getfield(rec, attr)
+Base.getindex(rec::T, attr::Symbol) where {T <: Record} = getproperty(rec, attr)
 Base.haskey(rec::T, attr::Symbol) where {T <: Record} = hasfield(T, attr)
 Base.keys(rec::T) where {T <: Record} = (fieldname(T, i) for i in 1:fieldcount(T))
 
@@ -97,21 +97,10 @@ function Base.iterate(rec::T, state=0) where T <: AttributeRecord
     return (fieldname(T, state) => get(getfield(rec, state)), state)
 end
 
-function getattribute end  # Remove when depwarn in `getindex` is removed
+Base.getproperty(rec::AttributeRecord, attr::Symbol) = get(getfield(rec, attr))
 
-function Base.getindex(rec::AttributeRecord, attr::Symbol)
-    if hasmethod(Memento.getattribute, (typeof(rec), Symbol))
-        Base.depwarn(
-            "Memento.getattribute is deprecated. Subtypes of `AttributeRecord` should " *
-            "implement Base.getproperty(::MyRecord, ::Symbol) instead.",
-            :getattribute
-        )
-        return get(getattribute(rec, attr))
-    end
-    return get(getproperty(rec, attr))
-end
+@deprecate getindex(rec::AttributeRecord, attr::Symbol) getproperty(rec::AttributeRecord, attr::Symbol)
 
-Base.getproperty(rec::AttributeRecord, attr::Symbol) = getfield(rec, attr)
 
 """
     Dict(rec::Record)

--- a/test/formatters.jl
+++ b/test/formatters.jl
@@ -4,8 +4,10 @@
     # NOTE: This check might not be needed as of 0.6 because I can't find a
     # condition where the stacktrace is empty.
     no_lookup = DefaultRecord(
-        rec.date, rec.level, rec.levelnum, rec.msg, rec.name, rec.pid,
-        Memento.Attribute(nothing), rec.stacktrace
+        Memento.Attribute(rec.date), Memento.Attribute(rec.level),
+        Memento.Attribute(rec.levelnum), Memento.Attribute(rec.msg),
+        Memento.Attribute(rec.name), Memento.Attribute(rec.pid),
+        Memento.Attribute(nothing), Memento.Attribute(rec.stacktrace)
     )
 
     @testset "DefaultFormatter" begin

--- a/test/records.jl
+++ b/test/records.jl
@@ -26,8 +26,8 @@
             rec = DefaultRecord("Logger.example", "info", 20, "blah")
 
             @test haskey(rec, :date)
-            @test rec[:date] == get(rec.date)
-            @test get(rec.date) == something(rec.date.x)
+            @test rec[:date] == rec.date
+            @test rec.date == something(rec.date)
 
             dict = Dict(rec)
             @test rec[:date] == dict[:date]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,7 +42,7 @@ SimpleRecord(level, msg) = SimpleRecord(level, msg, Dates.now(tz"UTC"))
 struct ConstRecord <: AttributeRecord
 end
 
-function Memento.getattribute(::ConstRecord, attr::Symbol)
+function Base.getproperty(::ConstRecord, attr::Symbol)
     if attr === :level
         return Memento.Attribute(() -> "error")
     elseif attr === :msg

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,9 +44,9 @@ end
 
 function Base.getproperty(::ConstRecord, attr::Symbol)
     if attr === :level
-        return Memento.Attribute(() -> "error")
+        return "error"
     elseif attr === :msg
-        return Memento.Attribute(() -> "It's a ConstRecord")
+        return "It's a ConstRecord"
     else
         throw(KeyError(attr))
     end


### PR DESCRIPTION
You can see the deprecation at work here: https://travis-ci.org/invenia/Memento.jl/jobs/512194767#L538

Closes #87 