### PR TITLE
Handle `occursin_msg(s, nothing)` fallback

### DIFF
--- a/src/memento_test.jl
+++ b/src/memento_test.jl
@@ -15,6 +15,7 @@ occursin_msg(s::AbstractString, output) = occursin(s, output)
 occursin_msg(s::Regex, output) = occursin(s, output)
 occursin_msg(s::Function, output) = s(output)
 occursin_msg(S::Union{AbstractArray,Tuple}, output) = all(s -> occursin_msg(s, output), S)
+occursin_msg(s, ::Nothing) = false  # Fallback, but shouldn't be needed
 
 """
     @test_log(logger, level, msg, expr)
@@ -56,8 +57,11 @@ macro test_log(logger, level, msg, expr)
 
             setpropagating!($(esc(logger)), false) do
                 ret = $(esc(expr))
-                @test handler.found[1] == $(esc(level))
-                @test occursin_msg($(esc(msg)), handler.found[2])
+
+                @test(
+                    handler.found[1] == $(esc(level)) &&
+                    occursin_msg($(esc(msg)), handler.found[2])
+                )
                 ret
             end
         finally

--- a/test/test.jl
+++ b/test/test.jl
@@ -24,7 +24,7 @@
         @test_nolog(logger, "info", msg, Memento.debug(logger, msg))
         @test_nolog(logger, "info", msg, Memento.info(logger, different_msg))
         @test_nolog(logger, "info", msg, Memento.warn(logger, different_msg))
-        @test_nolog(logger, "info", r".*foo.*", info(logger, "baz"))
+        @test_nolog(logger, "info", r".*foo.*", Memento.info(logger, "baz"))
     end
 
     @testset "@test_warn" begin

--- a/test/test.jl
+++ b/test/test.jl
@@ -24,6 +24,7 @@
         @test_nolog(logger, "info", msg, Memento.debug(logger, msg))
         @test_nolog(logger, "info", msg, Memento.info(logger, different_msg))
         @test_nolog(logger, "info", msg, Memento.warn(logger, different_msg))
+        @test_nolog(logger, "info", r".*foo.*", info(logger, "baz"))
     end
 
     @testset "@test_warn" begin


### PR DESCRIPTION
Only test occursin_msg after checking if the level was found. and `nothing` case. Closes #130 