### PR TITLE
Updated documentation, esp. conclusion.md, and fixed add_handler, STDOUT, current_module()

### DIFF
--- a/docs/quickstart.jl
+++ b/docs/quickstart.jl
@@ -11,6 +11,6 @@ critical(logger, "The world is exploding")
 child_logger = getlogger("Foo.bar")
 setlevel!(child_logger, "warn")
 push!(child_logger, DefaultHandler(tempname(), DefaultFormatter("[{date} | {level} | {name}]: {msg}")));
-debug(child_logger, "Something that should only be printed to STDOUT on the root_logger.")
-warn(child_logger, "Warning to STDOUT and the log file.")
+debug(child_logger, "Something that should only be printed to stdout on the root_logger.")
+warn(child_logger, "Warning to stdout and the log file.")
 exit()

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -6,9 +6,9 @@ Detailed docs on contributing to Julia packages can be found [here](http://docs.
 
 To start hacking code or writing docs, simply:
 
-1. `julia> Pkg.add("Memento"); Pkg.checkout("Memento")`
+1. `julia> using Pkg; Pkg.develop("Memento")`
 2. Make your changes.
-3. Test your changes with `julia --compilecache=no -e 'Pkg.test("Memento"; coverage=true)'`
+3. Test your changes with `julia --compiled-modules=no -e 'using Pkg; Pkg.test("Memento"; coverage=true)'`
 4. Check that your changes haven't reduced the test coverage. From the root Memento package folder run `julia -e 'using Coverage; Coverage.get_summary(process_folder())'`.
 5. Make a pull request to [Memento](https://github.com/invenia/Memento.jl) and share your changes with the rest of the community.
 

--- a/docs/src/faq/change-colors.md
+++ b/docs/src/faq/change-colors.md
@@ -3,10 +3,9 @@
 Colors can be enabled/disabled and set using via the `is_colorized` and `colors` options to the `DefaultHandler`.
 
 ```julia
-julia> add_handler(logger, DefaultHandler(
-    STDOUT, DefaultFormatter(),
-    Dict{Symbol, Any}(:is_colorized => true)),
-    "console"
+julia> push!(logger, DefaultHandler(
+    stdout, DefaultFormatter(),
+    Dict{Symbol, Any}(:is_colorized => true))
 )
 ```
 will create a `DefaultHandler` with colorization.
@@ -29,8 +28,8 @@ Dict{AbstractString, Symbol}(
 However, you can specify custom colors/log levels like so:
 
 ```julia
-add_handler(logger, DefaultHandler(
-    STDOUT, DefaultFormatter(),
+push!(logger, DefaultHandler(
+    stdout, DefaultFormatter(),
     Dict{Symbol, Any}(
         :colors => Dict{AbstractString, Symbol}(
             "debug" => :black,
@@ -39,8 +38,7 @@ add_handler(logger, DefaultHandler(
             "error" => :red,
             "crazy" => :green
         )
-    ),
-    "console"
+    )
 )
 ```
 

--- a/docs/src/faq/json-formatting.md
+++ b/docs/src/faq/json-formatting.md
@@ -8,12 +8,11 @@ However, the original behaviour can still be easily achieved by passing in `JSON
 ```julia
 using JSON
 
-add_handler(
+push!(
     logger,
     DefaultHandler(
         "json-output.log",
         DictFormatter(JSON.json)
-    ),
-    "JSON"
+    )
 )
 ```

--- a/docs/src/faq/logging-to-syslog.md
+++ b/docs/src/faq/logging-to-syslog.md
@@ -21,25 +21,23 @@ end
 Now we can start logging to syslog locally:
 
 ```julia
-add_handler(
+push!(
     logger,
     DefaultHandler(
         Syslog(),
         DefaultFormatter("{level}: {msg}")
-    ),
-    "Syslog"
+    )
 )
 ```
 
 We can also log to remote syslog servers via UDP or TCP:
 
 ```julia
-add_handler(
+push!(
     logger,
     DefaultHandler(
         Syslog(ip"123.34.56.78"),
         DefaultFormatter("{level}: {msg}")
-    ),
-    "Syslog"
+    )
 )
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -65,14 +65,14 @@ julia> push!(child_logger, DefaultHandler(tempname(), DefaultFormatter("[{date} 
 
 Memento.DefaultHandler{Memento.DefaultFormatter,IOStream}(Memento.DefaultFormatter("[{date} | {level} | {name}]: {msg}"),IOStream(<file /var/folders/_6/25myjdtx2fxgjvznn19rp22m0000gn/T/julia8lonyA>),Dict{Symbol,Any}(Pair{Symbol,Any}(:is_colorized,false)))
 
-julia> debug(child_logger, "Something that should only be printed to STDOUT on the root_logger.")
-[debug | Foo.bar]: Something that should only be printed to STDOUT on the root_logger.
+julia> debug(child_logger, "Something that should only be printed to stdout on the root_logger.")
+[debug | Foo.bar]: Something that should only be printed to stdout on the root_logger.
 
-julia> warn(child_logger, "Warning to STDOUT and the log file.")
-[warn | Foo.bar]: Warning to STDOUT and the log file.
+julia> warn(child_logger, "Warning to stdout and the log file.")
+[warn | Foo.bar]: Warning to stdout and the log file.
 ```
 
-NOTE: We used `getlogger("Foo.bar")`, but you can also do `getlogger(current_module())` which allows us to avoid hard coding in logger names.
+NOTE: We used `getlogger("Foo.bar")`, but you can also do `getlogger(@__MODULE__)` which allows us to avoid hard coding in logger names.
 
 ## Piggybacking onto another package's logger
 

--- a/docs/src/man/loggers.md
+++ b/docs/src/man/loggers.md
@@ -1,10 +1,10 @@
 # [Loggers](@id man_loggers)
 
 A [`Logger`](@ref) is the primary component you use to send formatted log messages to various IO outputs. This type holds information needed to manage the process of creating and storing logs. There is a default "root" logger stored in const `_loggers` inside the `Memento` module. Since Memento implements hierarchical logging you should define child loggers that can be configured independently and better describe the individual components within your code.
-To create a new logger for you code it is recommended to do `getlogger(current_module())`.
+To create a new logger for you code it is recommended to do `getlogger(@__MODULE__)`.
 
 ```julia
-julia> logger = getlogger(current_module())
+julia> logger = getlogger(@__MODULE__)
 ```
 
 Log messages are brought to different output streams by [`Handler`s](@ref man_handlers). From here you can add and remove handlers. To add a handler that writes to rotating log files, simply:

--- a/docs/src/man/records.md
+++ b/docs/src/man/records.md
@@ -44,7 +44,7 @@ mutable struct EC2Record <: AttributeRecord
             Attribute(levelnum),
             Attribute{AbstractString}(msg),
             Attribute(name),
-            Attribute(myid()),
+            Attribute(getpid()),
             Attribute{StackFrame}(get_lookup(trace)),
             trace,
             Attribute(ENV["INSTANCE_ID"]),

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -51,7 +51,7 @@ include("memento_test.jl")
 include("deprecated.jl")
 
 # Initializing at compile-time will work as long as the loggers which are added do not
-# contain references to STDOUT.
+# contain references to stdout.
 const _loggers = Dict{AbstractString, Logger}(
     "root" => Logger("root"),
 )

--- a/src/records.jl
+++ b/src/records.jl
@@ -160,7 +160,7 @@ function DefaultRecord(name::AbstractString, level::AbstractString, levelnum::In
         Attribute(levelnum),
         Attribute{AbstractString}(msg),
         Attribute(name),
-        Attribute(myid()),
+        Attribute(getpid()),
         Attribute{Union{StackFrame, Nothing}}(get_lookup(trace)),
         trace,
     )


### PR DESCRIPTION
Mostly documentation fixes.

Conclusion.md is much more functional than it was before.

In my application logs are often sent or written right as julia exits, and the `@async` logs wouldn't work in that case, so I added an `atexit()` hook for cleaning up the REST log tasks in the conclusion.md example to handle this case.