### PR TITLE
Fix overload of `getindex`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Memento"
 uuid = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 license = "MIT"
 authors = ["Invenia Technical Computing"]
-version = "0.13.0"
+version = "0.13.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,3 +1,10 @@
-@deprecate config(args...; kwargs...) config!(args...; kwargs...)
+using Base: @deprecate, @deprecate_binding
+import Base: getindex
 
-Base.@deprecate_binding Test Memento.TestUtils false
+# BEGIN Memento 0.12 deprecations
+
+@deprecate config(args...; kwargs...) config!(args...; kwargs...)
+@deprecate_binding Test Memento.TestUtils false
+@deprecate getindex(rec::T, attr::Symbol) where {T <: Record} getproperty(rec, attr) false
+
+# END Memento 0.12 deprecations

--- a/src/records.jl
+++ b/src/records.jl
@@ -78,7 +78,6 @@ Calling `getproperty` or iterating will evaluate and cache the properties access
 """
 abstract type AttributeRecord <: Record end
 
-@deprecate getindex(rec::T, attr::Symbol) where {T <: Record} getproperty(rec, attr)
 Base.haskey(rec::T, attr::Symbol) where {T <: Record} = hasfield(T, attr)
 Base.keys(rec::T) where {T <: Record} = (fieldname(T, i) for i in 1:fieldcount(T))
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,5 +1,0 @@
-# PkgBenchmark 0.0.1
-# BenchmarkTools 0.0.7
-Syslogs 0.1.1
-JSON 0.16.1
-Suppressor 0.0.5


### PR DESCRIPTION
An old deprecation was left in Memento which defines its own `getindex` function:

```julia
julia> using Memento

julia> getindex
WARNING: both Memento and Base export "getindex"; uses of it in module Main must be qualified
ERROR: UndefVarError: getindex not defined
```
Was introduced here: https://github.com/invenia/Memento.jl/commit/44cd87a4a4f3e6ec2c88cadbd3d3ae0a9b1397dc#diff-74d7f3cb64eee8b5198817d9027172f7L14