### PR TITLE
Avoid using unbounded dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Memento"
 uuid = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 license = "MIT"
 authors = ["Invenia Technical Computing"]
-version = "0.13.1"
+version = "0.13.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -16,9 +16,9 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-JSON = ">=0.16.1"
-Syslogs = ">=0.0.1"
-TimeZones = ">=0.7"
+JSON = "0.16.1, 0.17, 0.18, 0.19, 0.20, 0.21"
+Syslogs = "0.0.1, 0.1, 0.2, 0.3"
+TimeZones = "0.7, 0.8, 0.9, 0.10, 0.11, 1"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
Avoid stating Memento works with all future versions of packages Memento depends on.