### PR TITLE
Register parents

### DIFF
--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -143,8 +143,8 @@ function register(logger::Logger)
     end
 
     # Call getpath to potentially register any missing parent loggers.
-    # getpath(logger)
-    # return logger
+    getpath(logger)
+    return logger
 end
 
 """

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -141,6 +141,10 @@ function register(logger::Logger)
     else
         debug(LOGGER, "$logger is already registered.")
     end
+
+    # Call getpath to potentially register any missing parent loggers.
+    # getpath(logger)
+    # return logger
 end
 
 """

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -299,4 +299,9 @@
         logger = getlogger("new_logger")
         @test logger == original_logger
     end
+
+    @testset "No parent logger registered" begin
+        original_logger = Logger("foo.bar.baz")
+        @test !haskey(Memento._loggers, "foo.bar")
+    end
 end

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -302,6 +302,6 @@
 
     @testset "No parent logger registered" begin
         original_logger = Logger("foo.bar.baz")
-        @test !haskey(Memento._loggers, "foo.bar")
+        @test haskey(Memento._loggers, "foo.bar")
     end
 end


### PR DESCRIPTION
In some cases, you may end up registering a nested logger without the parent being registered. In these cases, we should autoregister the parent if it doesn't exist... otherwise it can lead to confusing behaviour.