### PR TITLE
First pass at improving load times

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Memento"
 uuid = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 license = "MIT"
 authors = ["Invenia Technical Computing"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -60,7 +60,6 @@ const _loggers = Dict{AbstractString, Logger}(
 )
 
 const LOGGER = getlogger(@__MODULE__)
-const _default_formatter = DefaultFormatter(DEFAULT_FMT_STRING)
 
 function __init__()
     Memento.config!(DEFAULT_LOG_LEVEL)

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -51,6 +51,7 @@ include("config.jl")
 include("exceptions.jl")
 include("memento_test.jl")
 include("deprecated.jl")
+include("precompile.jl")
 
 # Initializing at compile-time will work as long as the loggers which are added do not
 # contain references to stdout.
@@ -60,9 +61,22 @@ const _loggers = Dict{AbstractString, Logger}(
 
 const LOGGER = getlogger(@__MODULE__)
 
+# Cached values either to lazily load or precompile.
+const _default_formatter = DefaultFormatter(DEFAULT_FMT_STRING)
+const _localtz = Ref{Union{Dates.TimeZone, Nothing}}(nothing)
+
+function getlocalzone()
+    if _localtz[] === nothing
+        global _localtz[] = localzone()
+    end
+
+    return _localtz[]
+end
+
 function __init__()
     Memento.config!(DEFAULT_LOG_LEVEL)
     Memento.register(LOGGER)
 end
 
+_precompile_()
 end

--- a/src/Memento.jl
+++ b/src/Memento.jl
@@ -60,18 +60,7 @@ const _loggers = Dict{AbstractString, Logger}(
 )
 
 const LOGGER = getlogger(@__MODULE__)
-
-# Cached values either to lazily load or precompile.
 const _default_formatter = DefaultFormatter(DEFAULT_FMT_STRING)
-const _localtz = Ref{Union{Dates.TimeZone, Nothing}}(nothing)
-
-function getlocalzone()
-    if _localtz[] === nothing
-        global _localtz[] = localzone()
-    end
-
-    return _localtz[]
-end
 
 function __init__()
     Memento.config!(DEFAULT_LOG_LEVEL)

--- a/src/config.jl
+++ b/src/config.jl
@@ -39,7 +39,7 @@ function config!(
     setpropagating!(logger, propagate)
     handler = DefaultHandler(
         stdout,
-        fmt == DEFAULT_FMT_STRING ? _default_formatter : DefaultFormatter(fmt),
+        DefaultFormatter(fmt),
         Dict{Symbol, Any}(:is_colorized => colorized),
     )
     logger.handlers["console"] = handler

--- a/src/config.jl
+++ b/src/config.jl
@@ -39,7 +39,8 @@ function config!(
     setpropagating!(logger, propagate)
     handler = DefaultHandler(
         stdout,
-        DefaultFormatter(fmt), Dict{Symbol, Any}(:is_colorized => colorized)
+        fmt == DEFAULT_FMT_STRING ? _default_formatter : DefaultFormatter(fmt),
+        Dict{Symbol, Any}(:is_colorized => colorized),
     )
     logger.handlers["console"] = handler
     register(logger)

--- a/src/formatters.jl
+++ b/src/formatters.jl
@@ -45,6 +45,7 @@ struct DefaultFormatter <: Formatter
     end
 end
 
+
 """
     format(::DefaultFormatter, ::Record) -> String
 

--- a/src/formatters.jl
+++ b/src/formatters.jl
@@ -77,9 +77,8 @@ function format(fmt::DefaultFormatter, rec::Record)
                 value = string(" stack:[", join(str_frames, ", "), "]")
             elseif content === :date
                 value = if tmp_val isa ZonedDateTime
-                    # `localzone` is somewhat expensive, so we both delay calling it and
-                    # cache the result with our `getlocalzone` function.
-                    tzout = fmt.output_tz === nothing ? getlocalzone() : fmt.output_tz
+                    # `localzone` is expensive, so we don't call it until it is required.
+                    tzout = fmt.output_tz === nothing ? localzone() : fmt.output_tz
                     Dates.format(astimezone(tmp_val, tzout), DATE_FMT_STRING)
                 elseif tmp_val isa DateTime
                     Dates.format(tmp_val, DATE_FMT_STRING)

--- a/src/formatters.jl
+++ b/src/formatters.jl
@@ -25,11 +25,11 @@ Ex) "[{level} | {name}]: {msg}" will print message of the form
 struct DefaultFormatter <: Formatter
     fmt_str::AbstractString
     tokens::Vector{Pair{Symbol, Bool}}
-    output_tz::Dates.TimeZone
+    output_tz::Union{Dates.TimeZone, Nothing}
 
     function DefaultFormatter(
         fmt_str::AbstractString=DEFAULT_FMT_STRING,
-        output_tz=localzone(),
+        output_tz=nothing,
     )
         #r"(?<={).+?(?=})
         tokens = map(eachmatch(r"({.+?})|(.+?)", fmt_str)) do m
@@ -77,7 +77,10 @@ function format(fmt::DefaultFormatter, rec::Record)
                 value = string(" stack:[", join(str_frames, ", "), "]")
             elseif content === :date
                 value = if tmp_val isa ZonedDateTime
-                    Dates.format(astimezone(tmp_val, fmt.output_tz), DATE_FMT_STRING)
+                    # `localzone` is somewhat expensive, so we both delay calling it and
+                    # cache the result with our `getlocalzone` function.
+                    tzout = fmt.output_tz === nothing ? getlocalzone() : fmt.output_tz
+                    Dates.format(astimezone(tmp_val, tzout), DATE_FMT_STRING)
                 elseif tmp_val isa DateTime
                     Dates.format(tmp_val, DATE_FMT_STRING)
                 else

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,7 +1,9 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     # Memento
-    isdefined(Memento, Symbol("##config!#72")) && precompile(Tuple{getfield(Memento, Symbol("##config!#72")), Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, typeof(Memento.config!), String, String})
+    @assert precompile(Core.kwfunc(Memento.config!), (Vector{Any}, typeof(Memento.config!), String))
+    @assert precompile(Core.kwfunc(Memento.config!), (Vector{Any}, typeof(Memento.config!), String, String))
+    @assert precompile(Core.kwfunc(Memento.config!), (Vector{Any}, typeof(Memento.config!), Memento.Logger, String))
     @assert precompile(Tuple{typeof(Memento._log), Memento.Logger, String, String})
     @assert precompile(Tuple{typeof(Memento.config!), String})
     @assert precompile(Tuple{typeof(Memento.getlogger), String})
@@ -12,10 +14,8 @@ function _precompile_()
     # Unknown
     @assert precompile(Tuple{Type{Memento.DefaultHandler{F, O} where O<:IO where F}, Base.TTY, Memento.DefaultFormatter, Base.Dict{Symbol, Any}})
     @assert precompile(Tuple{Type{Memento.DefaultRecord}, String, String, Int64, String})
-    isdefined(Memento, Symbol("#level_filter#36")) && precompile(Tuple{getfield(Memento, Symbol("#level_filter#36")){Memento.Logger}, Memento.DefaultRecord})
 
     # Base
-    isdefined(Base, Symbol("##all#638")) && precompile(Tuple{getfield(Base, Symbol("##all#638")), typeof(identity), typeof(Base.all), typeof(identity), Array{Memento.Filter, 1}})
     @assert precompile(Tuple{typeof(Base.all), typeof(identity), Array{Memento.Filter, 1}})
     @assert precompile(Tuple{typeof(Base.get), Memento.Attribute{String}})
     @assert precompile(Tuple{typeof(Base.log), Memento.Logger, Memento.DefaultRecord})
@@ -27,8 +27,6 @@ function _precompile_()
     @assert precompile(Tuple{typeof(Base.show), Base.GenericIOBuffer{Array{UInt8, 1}}, Memento.Logger})
 
     # Manual
-    @assert precompile(Tuple{typeof(Memento.config!), String, String})
-    @assert precompile(Tuple{typeof(Memento.config!), Memento.Logger, String})
     @assert precompile(Tuple{typeof(Base.log), Memento.Logger, String, String})
     @assert precompile(Tuple{typeof(Memento.trace), Memento.Logger, String})
     @assert precompile(Tuple{typeof(Memento.debug), Memento.Logger, String})

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,36 +1,4 @@
 function _precompile_()
-    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    # Memento
-    @assert precompile(Core.kwfunc(Memento.config!), (Vector{Any}, typeof(Memento.config!), String))
-    @assert precompile(Core.kwfunc(Memento.config!), (Vector{Any}, typeof(Memento.config!), String, String))
-    @assert precompile(Core.kwfunc(Memento.config!), (Vector{Any}, typeof(Memento.config!), Memento.Logger, String))
-    @assert precompile(Tuple{typeof(Memento._log), Memento.Logger, String, String})
-    @assert precompile(Tuple{typeof(Memento.config!), String})
-    @assert precompile(Tuple{typeof(Memento.getlogger), String})
-    @assert precompile(Tuple{typeof(Memento.getpath), Memento.Logger})
-    @assert precompile(Tuple{typeof(Memento.isroot), Memento.Logger})
-    @assert precompile(Tuple{typeof(Memento.register), Memento.Logger})
-
-    # Unknown
-    @assert precompile(Tuple{Type{Memento.DefaultHandler{F, O} where O<:IO where F}, Base.TTY, Memento.DefaultFormatter, Base.Dict{Symbol, Any}})
-    @assert precompile(Tuple{Type{Memento.DefaultRecord}, String, String, Int64, String})
-
-    # Base
-    @assert precompile(Tuple{typeof(Base.all), typeof(identity), Array{Memento.Filter, 1}})
-    @assert precompile(Tuple{typeof(Base.get), Memento.Attribute{String}})
+    # Precompiling this one methods seems to cut our allocations during package loading in half.
     @assert precompile(Tuple{typeof(Base.log), Memento.Logger, Memento.DefaultRecord})
-    @assert precompile(Tuple{typeof(Base.print), Base.GenericIOBuffer{Array{UInt8, 1}}, Memento.Logger})
-    @assert precompile(Tuple{typeof(Base.print_to_string), Memento.Logger, Int})
-    @assert precompile(Tuple{typeof(Base.reverse!), Array{Memento.Logger, 1}, Int64, Int64})
-    @assert precompile(Tuple{typeof(Base.setindex!), Array{Memento.Logger, 1}, Memento.Logger, Int64})
-    @assert precompile(Tuple{typeof(Base.setindex!), Base.Dict{Any, Memento.Handler{F} where F<:Memento.Formatter}, Memento.DefaultHandler{Memento.DefaultFormatter, Base.TTY}, String})
-    @assert precompile(Tuple{typeof(Base.show), Base.GenericIOBuffer{Array{UInt8, 1}}, Memento.Logger})
-
-    # Manual
-    @assert precompile(Tuple{typeof(Base.log), Memento.Logger, String, String})
-    @assert precompile(Tuple{typeof(Memento.trace), Memento.Logger, String})
-    @assert precompile(Tuple{typeof(Memento.debug), Memento.Logger, String})
-    @assert precompile(Tuple{typeof(Memento.info), Memento.Logger, String})
-    @assert precompile(Tuple{typeof(Memento.warn), Memento.Logger, String})
-    @assert precompile(Tuple{typeof(Base.getindex), Base.Dict{AbstractString, Memento.Logger}, String})
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,38 @@
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    # Memento
+    isdefined(Memento, Symbol("##config!#72")) && precompile(Tuple{getfield(Memento, Symbol("##config!#72")), Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, typeof(Memento.config!), String, String})
+    @assert precompile(Tuple{typeof(Memento._log), Memento.Logger, String, String})
+    @assert precompile(Tuple{typeof(Memento.config!), String})
+    @assert precompile(Tuple{typeof(Memento.getlogger), String})
+    @assert precompile(Tuple{typeof(Memento.getpath), Memento.Logger})
+    @assert precompile(Tuple{typeof(Memento.isroot), Memento.Logger})
+    @assert precompile(Tuple{typeof(Memento.register), Memento.Logger})
+
+    # Unknown
+    @assert precompile(Tuple{Type{Memento.DefaultHandler{F, O} where O<:IO where F}, Base.TTY, Memento.DefaultFormatter, Base.Dict{Symbol, Any}})
+    @assert precompile(Tuple{Type{Memento.DefaultRecord}, String, String, Int64, String})
+    isdefined(Memento, Symbol("#level_filter#36")) && precompile(Tuple{getfield(Memento, Symbol("#level_filter#36")){Memento.Logger}, Memento.DefaultRecord})
+
+    # Base
+    isdefined(Base, Symbol("##all#638")) && precompile(Tuple{getfield(Base, Symbol("##all#638")), typeof(identity), typeof(Base.all), typeof(identity), Array{Memento.Filter, 1}})
+    @assert precompile(Tuple{typeof(Base.all), typeof(identity), Array{Memento.Filter, 1}})
+    @assert precompile(Tuple{typeof(Base.get), Memento.Attribute{String}})
+    @assert precompile(Tuple{typeof(Base.log), Memento.Logger, Memento.DefaultRecord})
+    @assert precompile(Tuple{typeof(Base.print), Base.GenericIOBuffer{Array{UInt8, 1}}, Memento.Logger})
+    @assert precompile(Tuple{typeof(Base.print_to_string), Memento.Logger, Int})
+    @assert precompile(Tuple{typeof(Base.reverse!), Array{Memento.Logger, 1}, Int64, Int64})
+    @assert precompile(Tuple{typeof(Base.setindex!), Array{Memento.Logger, 1}, Memento.Logger, Int64})
+    @assert precompile(Tuple{typeof(Base.setindex!), Base.Dict{Any, Memento.Handler{F} where F<:Memento.Formatter}, Memento.DefaultHandler{Memento.DefaultFormatter, Base.TTY}, String})
+    @assert precompile(Tuple{typeof(Base.show), Base.GenericIOBuffer{Array{UInt8, 1}}, Memento.Logger})
+
+    # Manual
+    @assert precompile(Tuple{typeof(Memento.config!), String, String})
+    @assert precompile(Tuple{typeof(Memento.config!), Memento.Logger, String})
+    @assert precompile(Tuple{typeof(Base.log), Memento.Logger, String, String})
+    @assert precompile(Tuple{typeof(Memento.trace), Memento.Logger, String})
+    @assert precompile(Tuple{typeof(Memento.debug), Memento.Logger, String})
+    @assert precompile(Tuple{typeof(Memento.info), Memento.Logger, String})
+    @assert precompile(Tuple{typeof(Memento.warn), Memento.Logger, String})
+    @assert precompile(Tuple{typeof(Base.getindex), Base.Dict{AbstractString, Memento.Logger}, String})
+end


### PR DESCRIPTION
Due to calling `config!` and `register` in the `__init__` function our load times were on the order of a few seconds.
To address this issue we've cached some default values (e.g., formatter, localzone) and added some precompile logic.

Before:
```
julia> @time using Memento
  1.289233 seconds (3.60 M allocations: 186.269 MiB, 3.61% gc time)
```

After:
```
julia> @time using Memento
  0.672002 seconds (1.13 M allocations: 64.016 MiB, 2.14% gc time)
```

NOTE: While `@time` isn't very reliable for times, you can see that we've reduced the number of allocations and amount of memory being allocated by about 1/2 and 1/3 respectively.

Similar to #163, but doesn't require lowering the optimization level.