### PR TITLE
implement Base.length for Record

### DIFF
--- a/src/records.jl
+++ b/src/records.jl
@@ -78,6 +78,7 @@ Calling `getproperty` or iterating will evaluate and cache the properties access
 """
 abstract type AttributeRecord <: Record end
 
+Base.length(rec::T) where T <: Record = fieldcount(T)
 Base.haskey(rec::T, attr::Symbol) where {T <: Record} = hasfield(T, attr)
 Base.keys(rec::T) where {T <: Record} = (fieldname(T, i) for i in 1:fieldcount(T))
 


### PR DESCRIPTION
This makes test pass on Julia master. It also allows showing Records in e.g.
the REPL while previously it would error with:

```
julia> rec = DefaultRecord("Logger.example", "info", 20, "blah")
Error showing value of type DefaultRecord:
ERROR: MethodError: no method matching length(::DefaultRecord)
Closest candidates are:
  length(::Cmd) at process.jl:639
  length(::CompositeException) at task.jl:41
  length(::Base.MethodList) at reflection.jl:869
  ...
Stacktrace:
 [1] summary(::IOContext{REPL.Terminals.TTYTerminal}, ::DefaultRecord) at ./abstractdict.jl:34
```