### PR TITLE
Allow date format on DefaultFormatter to be configured

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Memento"
 uuid = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 license = "MIT"
 authors = ["Invenia Technical Computing"]
-version = "1.1.2"
+version = "1.2.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/formatters.jl
+++ b/src/formatters.jl
@@ -8,7 +8,7 @@ log `Record`.
 abstract type Formatter end
 
 const DEFAULT_FMT_STRING = "[{level} | {name}]: {msg}"
-const DEFAULT_DATE_FMT_STRING = "yyyy-mm-dd HH:MM:SS"
+const DEFAULT_DATE_FMT = "yyyy-mm-dd HH:MM:SS"
 
 """
     DefaultFormatter
@@ -31,7 +31,7 @@ struct DefaultFormatter <: Formatter
     function DefaultFormatter(
         fmt_str::AbstractString=DEFAULT_FMT_STRING,
         output_tz=nothing;
-        date_fmt_string::AbstractString=DEFAULT_DATE_FMT_STRING,
+        date_fmt_string::AbstractString=DEFAULT_DATE_FMT,
     )
         #r"(?<={).+?(?=})
         tokens = map(eachmatch(r"({.+?})|(.+?)", fmt_str)) do m

--- a/test/formatters.jl
+++ b/test/formatters.jl
@@ -53,6 +53,17 @@
                 @test Memento.format(fmt, ts_rec) == string(ts)
             end
         end
+
+        @testset "Date format string" begin
+            date = ZonedDateTime(2012, 1, 1, 3, 1, 1, 123, localzone())
+            formats = ["yyyy", "yyyy-mm-dd HH:MM:SS.s"]
+            date_strings = ["2012", "2012-01-01 03:01:01.123"]
+            for (format, date_string) in zip(formats, date_strings)
+                formatter = DefaultFormatter("{date}"; date_fmt_string=format)
+                record = SimpleRecord("info", "moo", date)
+                @test Memento.format(formatter, record) == date_string
+            end
+        end
     end
 
     @testset "DictFormatter" begin


### PR DESCRIPTION
This addresses https://github.com/invenia/Memento.jl/issues/175, and allows a date format string to be given to `DefaultFormatter`.