### PR TITLE
Add thread id attribute to the DefaultRecord

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Memento"
 uuid = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 license = "MIT"
 authors = ["Invenia Technical Computing"]
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/man/intro.md
+++ b/docs/src/man/intro.md
@@ -74,6 +74,7 @@ levelnum | The integer value for the log event level
 msg | The source log event message
 name | The name of the source logger
 pid | The pid where the log event occured
+threadid | The thread id where the log event occured
 lookup | The top StackFrame of the stacktrace for the log event
 stacktrace | A StackTrace for the log event
 

--- a/docs/src/man/records.md
+++ b/docs/src/man/records.md
@@ -28,6 +28,7 @@ mutable struct EC2Record <: AttributeRecord
     msg::Attribute
     name::Attribute
     pid::Attribute
+    threadid::Attribute
     lookup::Attribute
     stacktrace::Attribute
     instance_id::Attribute
@@ -45,6 +46,7 @@ mutable struct EC2Record <: AttributeRecord
             Attribute{AbstractString}(msg),
             Attribute(name),
             Attribute(getpid()),
+            Attribute(Threads.threadid()),
             Attribute{StackFrame}(get_lookup(trace)),
             trace,
             Attribute(ENV["INSTANCE_ID"]),

--- a/src/records.jl
+++ b/src/records.jl
@@ -126,6 +126,7 @@ NOTE: if you'd like more logging attributes you can:
 * `msg::Attribute{AbstractString}`: the log message itself
 * `name::Attribute{AbstractString}`: the name of the source logger
 * `pid::Attribute{Int}`: the pid of where the log event occured
+* `threadid::Attribute{Int}`: the thread id of where the log event occured
 * `lookup::Attribute{StackFrame}`: the top StackFrame
 * `stacktrace::Attribute{StackTrace}`: a stacktrace
 """
@@ -136,6 +137,7 @@ struct DefaultRecord <: AttributeRecord
     msg::Attribute
     name::Attribute
     pid::Attribute
+    threadid::Attribute
     lookup::Attribute
     stacktrace::Attribute
 end
@@ -161,6 +163,7 @@ function DefaultRecord(name::AbstractString, level::AbstractString, levelnum::In
         Attribute{AbstractString}(msg),
         Attribute(name),
         Attribute(getpid()),
+        Attribute(Threads.threadid()),
         Attribute{Union{StackFrame, Nothing}}(get_lookup(trace)),
         trace,
     )

--- a/test/formatters.jl
+++ b/test/formatters.jl
@@ -7,6 +7,7 @@
         Memento.Attribute(rec.date), Memento.Attribute(rec.level),
         Memento.Attribute(rec.levelnum), Memento.Attribute(rec.msg),
         Memento.Attribute(rec.name), Memento.Attribute(rec.pid),
+        Memento.Attribute(rec.threadid),
         Memento.Attribute(nothing), Memento.Attribute(rec.stacktrace)
     )
 

--- a/test/records.jl
+++ b/test/records.jl
@@ -30,6 +30,9 @@
 
             dict = Dict(rec)
             @test rec.date == dict[:date]
+
+            @test haskey(rec, :threadid)
+            @test isinteger(rec.threadid)
         end
     end
 end


### PR DESCRIPTION
To help debug multi-threaded code.

Seems pretty fast so low overhead:
```
julia> @btime Threads.threadid()
  2.800 ns (0 allocations: 0 bytes)
1
```