### PR TITLE
Add FAQ entry for changing the date format

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,6 +24,7 @@ makedocs(
         "FAQ" => Any[
             "faq/another-logging-lib.md",
             "faq/change-colors.md",
+            "faq/change-date-format.md",
             "faq/config-recipes.md",
             "faq/logging-to-syslog.md",
             "faq/json-formatting.md",

--- a/docs/src/faq/change-date-format.md
+++ b/docs/src/faq/change-date-format.md
@@ -1,0 +1,9 @@
+# [Changing date format?](@id change_date_format)
+
+The default date format is `yyyy-mm-dd HH:MM:SS`.
+To change that, for example if you want to display milliseconds, you'll have to change the `Formatter` like so:
+
+```julia
+# Changes the formatter of the console handler of the root logger
+gethandlers(getlogger())["console"].fmt = DefaultFormatter("[{date} | {name} | {level}]: {msg}"; date_fmt_string="yyyy-mm-dd HH:MM:SS.sss")
+```


### PR DESCRIPTION
I and at least one other person have needed this, I'm guessing it's common enough to have a FAQ entry.

Just not sure of the proposed solution, but this works for my case (changes the console handler for the root logger).
Should we suggest to the reader to do this for every handler they have? Unsure if/how the handlers & formatters get re-used in the logger hierarchy.