### PR TITLE
Reroute `nothing` stdlib `mod` to the root logger

### DIFF
--- a/src/stdlib.jl
+++ b/src/stdlib.jl
@@ -35,3 +35,7 @@ function substitute!(level::LogLevel=min_enabled_level(global_logger()))
     global_logger(BaseLogger(level))
     notice(getlogger(@__MODULE__), "Substituting global logging with Memento")
 end
+
+# Simple `getlogger` dispatch if the base logging library passes `nothing` as the mod.
+# This just reroutes the message to the root logger similar to calling `getlogger` with no arguments.
+getlogger(::Nothing) = getlogger()


### PR DESCRIPTION
Closes #181 

NOTE: This seems more internally consistent than having a separate logger for this case?