### PR TITLE
Support forced re-registration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Memento"
 uuid = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 license = "MIT"
 authors = ["Invenia Technical Computing"]
-version = "1.3.1"
+version = "1.4.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -135,9 +135,10 @@ getlevels(logger::Logger) = logger.levels
 
 Register an existing logger with Memento if it has not already been registered.
 
-NOTE: You can re-register a logger with `force=true`.
-This may be necessary if you want to explicitly register a parent logger after
-registering the child one, such as in submodule `__init__` functions.
+!!! note `force=true`
+    You can re-register a logger with `force=true`.
+    This may be necessary if you want to explicitly register a parent logger after
+    registering the child one, such as in submodule `__init__` functions.
 """
 function register(logger::Logger; force=false)
     if !haskey(_loggers, logger.name) || force

--- a/src/loggers.jl
+++ b/src/loggers.jl
@@ -131,15 +131,19 @@ Get the available log levels for a logger and their associated priorities.
 getlevels(logger::Logger) = logger.levels
 
 """
-    register(::Logger)
+    register(::Logger; force=false)
 
 Register an existing logger with Memento if it has not already been registered.
+
+NOTE: You can re-register a logger with `force=true`.
+This may be necessary if you want to explicitly register a parent logger after
+registering the child one, such as in submodule `__init__` functions.
 """
-function register(logger::Logger)
-    if !haskey(_loggers, logger.name)
+function register(logger::Logger; force=false)
+    if !haskey(_loggers, logger.name) || force
         _loggers[logger.name] = logger
     else
-        debug(LOGGER, "$logger is already registered.")
+        debug(LOGGER, "$logger is already registered and force=false.")
     end
 
     # Call getpath to potentially register any missing parent loggers.

--- a/test/loggers.jl
+++ b/test/loggers.jl
@@ -298,6 +298,10 @@
         Memento.register(Logger("new_logger"))
         logger = getlogger("new_logger")
         @test logger == original_logger
+
+        # Test forced re-registration
+        logger = Memento.register(Logger("new_logger"; level="debug"); force=true)
+        @test logger != original_logger
     end
 
     @testset "No parent logger registered" begin


### PR DESCRIPTION
Add an optional kwarg to support forced re-registration of loggers. This is useful in cases where you want/need to override the default registration of parent loggers.

Example)
```julia
module Parent

const LOGGER = getlogger(@__MODULE__)

# This line won't get called until after the Child module is loaded and a Logger("Parent") has been added.
# Adding `force=true` make sure that the `LOGGER` above is registered cause that's what we're 
# referencing in our code.
__init__() = Memento.register(LOGGER; force=true)

module Child

const LOGGER = getlogger(@__MODULE__)

# For convenience this also registers a parent logger for cases where a parent isn't explicitly needed by the package,
# but is helpful for configuration management.
__init__() = Memento.register(LOGGER)

end

end
```