### PR TITLE
Updates `AsyncHandler` test case to accommodate fix added in v1.8.0-beta1

### DIFF
--- a/test/handlers.jl
+++ b/test/handlers.jl
@@ -96,7 +96,6 @@
                 msg = "It works!"
                 Memento.info(logger, msg)
                 wait_for_empty(handler.channel)
-                str1 = String(take!(io))
                 @test occursin(msg, String(take!(io)))
 
                 Memento.debug(logger, "This shouldn't get logged")

--- a/test/handlers.jl
+++ b/test/handlers.jl
@@ -114,15 +114,17 @@
                     Memento.info(LOGGER, i)  # ERROR: cannot serialize a running Task
                 end
                 =#
-                try
-                    serialize(io, handler)
-                    @test false
-                catch e
-                    @test e isa ErrorException
-                    @test e.msg == "cannot serialize a running Task"
-                end
+                if VERSION < v"1.8.0-beta1"
+                    try
+                        serialize(io, handler)
+                        @test false
+                    catch e
+                        @test e isa ErrorException
+                        @test e.msg == "cannot serialize a running Task"
+                    end
 
-                @test_throws LoggerSerializationError serialize(io, logger)
+                    @test_throws LoggerSerializationError serialize(io, logger)
+                end
             finally
                 close(io)
             end

--- a/test/handlers.jl
+++ b/test/handlers.jl
@@ -128,6 +128,7 @@
                 else
                     serialize(deserialized_io, logger)
                     seekstart(deserialized_io)
+                    # Note: The deserialized logger and handler are different than the serialized one
                     l = deserialize(deserialized_io)
                     @test typeof(l) == Logger
                     deserialized_handler = l.handlers["Buffer"]


### PR DESCRIPTION
Previously, there was a test case for where serializing io with an AsyncHandler caused an exception. Memento was changed to accommodate this fix [here](https://github.com/invenia/Memento.jl/pull/114).

With the changes made to v`1.8.0-beta1` (the addition of [support AbstractLock and GenericCondition](https://github.com/JuliaLang/julia/pull/43325)), this case no longer needs to be covered.

Fixes: #184