### PR TITLE
Backport stdlib mod nothing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Memento"
 uuid = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 license = "MIT"
 authors = ["Invenia Technical Computing"]
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/stdlib.jl
+++ b/src/stdlib.jl
@@ -35,3 +35,7 @@ function substitute!(level::LogLevel=min_enabled_level(global_logger()))
     global_logger(BaseLogger(level))
     notice(getlogger(@__MODULE__), "Substituting global logging with Memento")
 end
+
+# `getlogger` dispatch to reroute stdlib messages with `mod=nothing` to the root logger, 
+# similar to calling `getlogger` with no arguments.
+getlogger(::Nothing) = getlogger()

--- a/test/stdlib.jl
+++ b/test/stdlib.jl
@@ -1,5 +1,6 @@
 @testset "stdlib" begin
     orig_logger = Base.CoreLogging.global_logger()
+    @test getlogger(nothing) == getlogger()
 
     try
         logger = getlogger("Memento")


### PR DESCRIPTION
Backport of https://github.com/invenia/Memento.jl/pull/185/ for the 1.2.0 branch (which I created from the `v1.2.0` tag for the occasion - let me know if that's not the right process).

This is so that CloudWatchLogs can pull in the fix (there Memento is [upper-bounded to 1.2 due to date representation differences](https://github.com/invenia/CloudWatchLogs.jl/pull/41)).