### PR TITLE
Bumps version number to accommodate previous PR

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Memento"
 uuid = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
 license = "MIT"
 authors = ["Invenia Technical Computing"]
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
Forgot to bump the version number for this PR [here](https://github.com/invenia/Memento.jl/pull/189).