### PR TITLE
Clarify docstring for `Filter`

### DIFF
--- a/src/filters.jl
+++ b/src/filters.jl
@@ -3,7 +3,7 @@
 
 A wrapper around a function that takes a log `Record` and returns
 a bool indicating whether to log it.
-`false` means "skip logging this record". 
+`false` means "skip logging this record", similar to `Base.filter`. 
 
 # Fields
 `f::Function`: a function that should return a bool given a `Record`

--- a/src/filters.jl
+++ b/src/filters.jl
@@ -2,7 +2,8 @@
     Filter
 
 A wrapper around a function that takes a log `Record` and returns
-a bool whether to skip logging it.
+a bool indicating whether to log it.
+`false` means "skip logging this record". 
 
 # Fields
 `f::Function`: a function that should return a bool given a `Record`


### PR DESCRIPTION
To me, the prior docstring indicated the opposite behaviour.